### PR TITLE
Fix bug preventing content property being accessed from Swift

### DIFF
--- a/evernote-sdk-ios/ENSDK/Private/ENSDKPrivate.h
+++ b/evernote-sdk-ios/ENSDK/Private/ENSDKPrivate.h
@@ -64,7 +64,7 @@ extern NSString * const ENBootstrapProfileNameChina;
 
 @interface ENNote (Private)
 - (id)initWithServiceNote:(EDAMNote *)note;
-- (NSString *)content;
+- (NSString *)enmlContent;
 - (void)setGuid:(NSString *)guid;
 - (void)setEnmlContent:(NSString *)enmlContent;
 - (void)setResources:(NSArray *)resources;


### PR DESCRIPTION
- Don't redefine a property with a different type (why this is not a compiler error I don't know)