### PR TITLE
Simplify completion blocks

### DIFF
--- a/evernote-sdk-ios/ENSDK/Advanced/ENBusinessNoteStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENBusinessNoteStoreClient.h
@@ -43,11 +43,19 @@
  
  @param  notebook The desired fields for the notebook must be provided on this object. The name of the notebook must be set. If a notebook exists in the business account with the same name (via case-insensitive compare), this will throw an EDAMUserException.
  
- @param success Success completion block with the newly created Notebook. The server-side GUID will be saved in this object's 'guid' field.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)createBusinessNotebook:(EDAMNotebook *)notebook
-               success:(void(^)(EDAMLinkedNotebook *notebook))success
-               failure:(void(^)(NSError *error))failure;
+                    completion:(void(^)(EDAMLinkedNotebook *notebook, NSError *error))completion;
+
+@end
+
+//Deprecated
+@interface ENBusinessNoteStoreClient ()
+
+- (void)createBusinessNotebook:(EDAMNotebook *)notebook
+                       success:(void(^)(EDAMLinkedNotebook *notebook))success
+                       failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -createBusinessNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 @end

--- a/evernote-sdk-ios/ENSDK/Advanced/ENBusinessNoteStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENBusinessNoteStoreClient.m
@@ -48,24 +48,30 @@
 }
 
 - (void)createBusinessNotebook:(EDAMNotebook *)notebook
-                       success:(void(^)(EDAMLinkedNotebook *notebook))success
-                       failure:(void(^)(NSError *error))failure
+                    completion:(void(^)(EDAMLinkedNotebook *notebook, NSError *error))completion
 {
-    [self createNotebook:notebook success:^(EDAMNotebook *businessNotebook) {
+    [self createNotebook:notebook completion:^(EDAMNotebook *businessNotebook, NSError *error) {
+        if (error != nil) {
+            completion(nil, error);
+            return;
+        }
         EDAMSharedNotebook *sharedNotebook = businessNotebook.sharedNotebooks[0];
         EDAMLinkedNotebook *linkedNotebook = [[EDAMLinkedNotebook alloc] init];
         [linkedNotebook setSharedNotebookGlobalId:sharedNotebook.globalId];
         [linkedNotebook setShareName:[businessNotebook name]];
         [linkedNotebook setUsername:[ENSession sharedSession].businessUser.username];
         [linkedNotebook setShardId:[ENSession sharedSession].businessUser.shardId];
-        [[ENSession sharedSession].primaryNoteStore createLinkedNotebook:linkedNotebook success:^(EDAMLinkedNotebook *businessLinkedNotebook) {
-            success(businessLinkedNotebook);
-        } failure:^(NSError *error) {
-            failure(error);
-        }];
-    } failure:^(NSError *error) {
-        failure(error);
+        [[ENSession sharedSession].primaryNoteStore createLinkedNotebook:linkedNotebook completion:completion];
     }];
 }
 
+
+- (void)createBusinessNotebook:(EDAMNotebook *)notebook
+                       success:(void(^)(EDAMLinkedNotebook *notebook))success
+                       failure:(void(^)(NSError *error))failure
+{
+    [self createBusinessNotebook:notebook completion:^(EDAMLinkedNotebook *createdNotebook, NSError *error) {
+        (error != nil) ? success(createdNotebook) : failure(error);
+    }];
+}
 @end

--- a/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.h
@@ -75,15 +75,10 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
 
 /** Asks the NoteStore to provide information about the status of the user account corresponding to the provided authentication token.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)fetchSyncStateWithSuccess:(void(^)(EDAMSyncState *syncState))success
-                          failure:(void(^)(NSError *error))failure;
+- (void)fetchSyncStateWithCompletion:(void(^)(EDAMSyncState *_Nullable syncState, NSError *_Nullable error))completion;
 
-- (void)getSyncStateWithSuccess:(void(^)(EDAMSyncState *syncState))success
-                        failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncStateWithSuccess:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 /** Asks the NoteStore to provide the state of the account in order of last modification.
  
  This request retrieves one block of the server's state so that a client can make several small requests against a large account rather than getting the entire state in one big message.
@@ -94,21 +89,13 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  fullSyncOnly If true, then the client only wants initial data for a full sync. In this case, the service will not return any expunged objects, and will not return any Resources, since these are also provided in their corresponding Notes.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchSyncChunkAfterUSN:(int32_t)afterUSN
                     maxEntries:(int32_t)maxEntries
                   fullSyncOnly:(BOOL)fullSyncOnly
-                       success:(void(^)(EDAMSyncChunk *syncChunk))success
-                       failure:(void(^)(NSError *error))failure;
+                    completion:(void(^)(EDAMSyncChunk *_Nullable syncChunk, NSError *_Nullable error))completion;
 
-- (void)getSyncChunkAfterUSN:(int32_t)afterUSN
-                  maxEntries:(int32_t)maxEntries
-                fullSyncOnly:(BOOL)fullSyncOnly
-                     success:(void(^)(EDAMSyncChunk *syncChunk))success
-                     failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncChunkAfterUSN:maxEntries:fullSyncOnly:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 /** Asks the NoteStore to provide the state of the account in order of last modification.
  
  This request retrieves one block of the server's state so that a client can make several small requests against a large account rather than getting the entire state in one big message. This call gives more fine-grained control of the data that will be received by a client by omitting data elements that a client doesn't need. This may reduce network traffic and sync times.
@@ -119,21 +106,13 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  filter The caller must set some of the flags in this structure to specify which data types should be returned during the synchronization. See the SyncChunkFilter structure for information on each flag.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchFilteredSyncChunkAfterUSN:(int32_t)afterUSN
                             maxEntries:(int32_t)maxEntries
                                 filter:(EDAMSyncChunkFilter *)filter
-                               success:(void(^)(EDAMSyncChunk *syncChunk))success
-                               failure:(void(^)(NSError *error))failure;
+                            completion:(void(^)(EDAMSyncChunk *_Nullable syncChunk, NSError *_Nullable error))completion;
 
-- (void)getFilteredSyncChunkAfterUSN:(int32_t)afterUSN
-                          maxEntries:(int32_t)maxEntries
-                              filter:(EDAMSyncChunkFilter *)filter
-                             success:(void(^)(EDAMSyncChunk *syncChunk))success
-                             failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchFilteredSyncChunkAfterUSN:maxEntries:filter:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 /** Asks the NoteStore to provide information about the status of a linked notebook that has been shared with the caller, or that is public to the world.
  
  This will return a result that is similar to getSyncState, but may omit SyncState.uploaded if the caller doesn't have permission to write to the linked notebook.
@@ -141,17 +120,11 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  linkedNotebook This structure should contain identifying information and permissions to access the notebook in question.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchSyncStateForLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
-                             success:(void(^)(EDAMSyncState *syncState))success
-                             failure:(void(^)(NSError *error))failure;
+                             completion:(void(^)(EDAMSyncState *_Nullable syncState, NSError *_Nullable error))completion;
 
-- (void)getLinkedNotebookSyncState:(EDAMLinkedNotebook *)linkedNotebook
-                           success:(void(^)(EDAMSyncState *syncState))success
-                           failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncStateForLinkedNotebook:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 /** Asks the NoteStore to provide information about the contents of a linked notebook that has been shared with the caller, or that is public to the world.
  
  This will return a result that is similar to getSyncChunk, but will only contain entries that are visible to the caller. I.e. only that particular Notebook will be visible, along with its Notes, and Tags on those Notes.
@@ -165,23 +138,13 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  fullSyncOnly If true, then the client only wants initial data for a full sync. In this case, the service will not return any expunged objects, and will not return any Resources, since these are also provided in their corresponding Notes.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchSyncChunkForLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
                                afterUSN:(int32_t)afterUSN
                              maxEntries:(int32_t)maxEntries
                            fullSyncOnly:(BOOL)fullSyncOnly
-                                success:(void(^)(EDAMSyncChunk *syncChunk))success
-                                failure:(void(^)(NSError *error))failure;
-
-- (void)getLinkedNotebookSyncChunk:(EDAMLinkedNotebook *)linkedNotebook
-                          afterUSN:(int32_t)afterUSN
-                        maxEntries:(int32_t)maxEntries
-                      fullSyncOnly:(BOOL)fullSyncOnly
-                           success:(void(^)(EDAMSyncChunk *syncChunk))success
-                           failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncChunkForLinkedNotebook:afterUSN:maxEntries:fullSyncOnly:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                             completion:(void(^)(EDAMSyncChunk *_Nullable syncChunk, NSError *_Nullable error))completion;
 
 ///---------------------------------------------------------------------------------------
 /// @name NoteStore notebook methods
@@ -189,69 +152,50 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
 
 /** Returns a list of all of the notebooks in the account.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)listNotebooksWithSuccess:(void(^)(NSArray<EDAMNotebook *> *notebooks))success
-                         failure:(void(^)(NSError *error))failure;
+- (void)listNotebooksWithCompletion:(void(^)(NSArray<EDAMNotebook *> *_Nullable notebooks, NSError *_Nullable error))completion;
 
 /** Returns the current state of the notebook with the provided GUID. The notebook may be active or deleted (but not expunged).
  
  @param  guid The GUID of the notebook to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchNotebookWithGuid:(EDAMGuid)guid
-                      success:(void(^)(EDAMNotebook *notebook))success
-                      failure:(void(^)(NSError *error))failure;
+                   completion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion;
 
-- (void)getNotebookWithGuid:(EDAMGuid)guid
-                    success:(void(^)(EDAMNotebook *notebook))success
-                    failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchNotebookWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 /** Returns the notebook that should be used to store new notes in the user's account when no other notebooks are specified.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)fetchDefaultNotebookWithSuccess:(void(^)(EDAMNotebook *notebook))success
-                                failure:(void(^)(NSError *error))failure;
+- (void)fetchDefaultNotebookWithCompletion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion;
 
-- (void)getDefaultNotebookWithSuccess:(void(^)(EDAMNotebook *notebook))success
-                              failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchDefaultNotebookWithSuccess:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 
 /** Asks the service to make a notebook with the provided name.
  
  @param  notebook The desired fields for the notebook must be provided on this object. The name of the notebook must be set, and either the 'active' or 'defaultNotebook' fields may be set by the client at creation. If a notebook exists in the account with the same name (via case-insensitive compare), this will throw an EDAMUserException.
  
- @param success Success completion block with the newly created Notebook. The server-side GUID will be saved in this object's 'guid' field.
- @param failure Failure completion block.
+ @param completion Success completion block with the newly created Notebook. The server-side GUID will be saved in this object's 'guid' field.
  */
 - (void)createNotebook:(EDAMNotebook *)notebook
-               success:(void(^)(EDAMNotebook *notebook))success
-               failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(create(_:success:failure:));
+            completion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion NS_SWIFT_NAME(create(_:completion:));
 
 /** Submits notebook changes to the service. The provided data must include the notebook's guid field for identification.
  
  @param  notebook The notebook object containing the requested changes.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateNotebook:(EDAMNotebook *)notebook
-               success:(void(^)(int32_t usn))success
-               failure:(void(^)(NSError *error))failure;
+            completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Permanently removes the notebook from the user's account. After this action, the notebook is no longer available for undeletion, etc. If the notebook contains any Notes, they will be moved to the current default notebook and moved into the trash (i.e. Note.active=false).
  
  @param  guid The GUID of the notebook to delete.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeNotebookWithGuid:(EDAMGuid)guid
-                        success:(void(^)(int32_t usn))success
-                        failure:(void(^)(NSError *error))failure;
+                     completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 ///---------------------------------------------------------------------------------------
 /// @name NoteStore tag methods
@@ -259,144 +203,104 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
 
 /** Returns a list of the tags in the account. Evernote does not support the undeletion of tags, so this will only include active tags.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)listTagsWithSuccess:(void(^)(NSArray<EDAMTag *> *tags))success
-                    failure:(void(^)(NSError *error))failure;
+- (void)listTagsWithCompletion:(void(^)(NSArray<EDAMTag *> *_Nullable tags, NSError *_Nullable error))completion;
 
 /** Returns a list of the tags that are applied to at least one note within the provided notebook. If the notebook is public, the authenticationToken may be ignored.
  
  @param  guid the GUID of the notebook to use to find tags
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)listTagsInNotebookWithGuid:(EDAMGuid)guid
-                           success:(void(^)(NSArray<EDAMTag *> *tags))success
-                           failure:(void(^)(NSError *error))failure;
-
-- (void)listTagsByNotebookWithGuid:(EDAMGuid)guid
-                           success:(void(^)(NSArray<EDAMTag *> *tags))success
-                           failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -listTagsInNotebookWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
-
+                        completion:(void(^)(NSArray<EDAMTag *> * _Nullable tags, NSError *_Nullable error))completion;
 
 /** Returns the current state of the Tag with the provided GUID.
  
  @param  guid The GUID of the tag to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchTagWithGuid:(EDAMGuid)guid
-                 success:(void(^)(EDAMTag *tag))success
-                 failure:(void(^)(NSError *error))failure;
-
-- (void)getTagWithGuid:(EDAMGuid)guid
-               success:(void(^)(EDAMTag *tag))success
-               failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchTagWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+              completion:(void(^)(EDAMTag *_Nullable tag, NSError *_Nullable error))completion;
 
 /** Asks the service to make a tag with a set of information.
  
  @param  tag The desired list of fields for the tag are specified in this object. The caller must specify the tag name, and may provide the parentGUID.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)createTag:(EDAMTag *)tag
-          success:(void(^)(EDAMTag *tag))success
-          failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(create(_:success:failure:));
+       completion:(void(^)(EDAMTag *_Nullable tag, NSError *_Nullable error))completion NS_SWIFT_NAME(create(_:completion:));
 
 /** Submits tag changes to the service. The provided data must include the tag's guid field for identification. The service will apply updates to the following tag fields: name, parentGuid
  
  @param  tag The tag object containing the requested changes.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateTag:(EDAMTag *)tag
-          success:(void(^)(int32_t usn))success
-          failure:(void(^)(NSError *error))failure;
+       completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Removes the provided tag from every note that is currently tagged with this tag. If this operation is successful, the tag will still be in the account, but it will not be tagged on any notes.
  
  This function is not indended for use by full synchronizing clients, since it does not provide enough result information to the client to reconcile the local state without performing a follow-up sync from the service. This is intended for "thin clients" that need to efficiently support this as a UI operation.
  
  @param  guid The GUID of the tag to remove from all notes.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)untagAllWithGuid:(EDAMGuid)guid
-                 success:(void(^)())success
-                 failure:(void(^)(NSError *error))failure;
+              completion:(void(^)(NSError *error))completion;
 
 /** Permanently deletes the tag with the provided GUID, if present.
  
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
  @param  guid The GUID of the tag to delete.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeTagWithGuid:(EDAMGuid)guid
-                   success:(void(^)(int32_t usn))success
-                   failure:(void(^)(NSError *error))failure;
+                completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 ///---------------------------------------------------------------------------------------
 /// @name NoteStore SavedSearch methods
 ///---------------------------------------------------------------------------------------
 
 /** Returns a list of the searches in the account. Evernote does not support the undeletion of searches, so this will only include active searches.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)listSearchesWithSuccess:(void(^)(NSArray<EDAMSavedSearch *> *searches))success
-                        failure:(void(^)(NSError *error))failure;
+- (void)listSearchesWithCompletion:(void(^)(NSArray<EDAMSavedSearch *> *_Nullable searches, NSError *_Nullable error))completion;
 
 /** Returns the current state of the search with the provided GUID.
  
  @param  guid The GUID of the search to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchSearchWithGuid:(EDAMGuid)guid
-                    success:(void(^)(EDAMSavedSearch *search))success
-                    failure:(void(^)(NSError *error))failure;
-
-- (void)getSearchWithGuid:(EDAMGuid)guid
-                  success:(void(^)(EDAMSavedSearch *search))success
-                  failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchSearchWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                 completion:(void(^)(EDAMSavedSearch *_Nullable search, NSError *_Nullable error))completion;
 
 /** Asks the service to make a saved search with a set of information.
  
  @param  search The desired list of fields for the search are specified in this object. The caller must specify the name, query, and format of the search.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)createSearch:(EDAMSavedSearch *)search
-             success:(void(^)(EDAMSavedSearch *search))success
-             failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(create(_:success:failure:));
+          completion:(void(^)(EDAMSavedSearch *_Nullable search, NSError *_Nullable error))completion NS_SWIFT_NAME(create(_:completion:));
 
 /** Submits search changes to the service. The provided data must include the search's guid field for identification. The service will apply updates to the following search fields: name, query, and format.
  
  @param  search The search object containing the requested changes.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateSearch:(EDAMSavedSearch *)search
-             success:(void(^)(int32_t usn))success
-             failure:(void(^)(NSError *error))failure;
+          completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Permanently deletes the saved search with the provided GUID, if present.
  
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
  @param  guid The GUID of the search to delete.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeSearchWithGuid:(EDAMGuid)guid
-                      success:(void(^)(int32_t usn))success
-                      failure:(void(^)(NSError *error))failure;
+                   completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 ///---------------------------------------------------------------------------------------
 /// @name NoteStore notes methods
 ///---------------------------------------------------------------------------------------
@@ -405,13 +309,11 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  query The information about which we are finding related entities.
  @param  resultSpec Allows the client to indicate the type and quantity of information to be returned, allowing a saving of time and bandwidth.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)findRelatedWithQuery:(EDAMRelatedQuery *)query
                   resultSpec:(EDAMRelatedResultSpec *)resultSpec
-                     success:(void(^)(EDAMRelatedResult *result))success
-                     failure:(void(^)(NSError *error))failure;
+                  completion:(void(^)(EDAMRelatedResult *_Nullable result, NSError *_Nullable error))completion;
 
 /** Used to find a set of the notes from a user's account based on various criteria specified via a NoteFilter object.
  
@@ -422,14 +324,12 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  @param  offset The numeric index of the first note to show within the sorted results. The numbering scheme starts with "0". This can be used for pagination.
  
  @param  maxNotes The most notes to return in this query. The service will return a set of notes that is no larger than this number, but may return fewer notes if needed. The NoteList.totalNotes field in the return value will indicate whether there are more values available after the returned set.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)findNotesWithFilter:(EDAMNoteFilter *)filter
                      offset:(int32_t)offset
                    maxNotes:(int32_t)maxNotes
-                    success:(void(^)(EDAMNoteList *list))success
-                    failure:(void(^)(NSError *error))failure;
+                 completion:(void(^)(EDAMNoteList *_Nullable list, NSError *_Nullable error))completion;
 
 /** Finds the position of a note within a sorted subset of all of the user's notes.
  
@@ -439,13 +339,11 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  guid The GUID of the note to be retrieved.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)findNoteOffsetWithFilter:(EDAMNoteFilter *)filter
                             guid:(EDAMGuid)guid
-                         success:(void(^)(int32_t offset))success
-                         failure:(void(^)(NSError *error))failure;
+                      completion:(void(^)(int32_t offset , NSError *_Nullable error))completion;
 
 /** Used to find the high-level information about a set of the notes from a user's account based on various criteria specified via a NoteFilter object.
  
@@ -459,15 +357,13 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  resultSpec This specifies which information should be returned for each matching Note. The fields on this structure can be used to eliminate data that the client doesn't need, which will reduce the time and bandwidth to receive and process the reply.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)findNotesMetadataWithFilter:(EDAMNoteFilter *)filter
                              offset:(int32_t)offset
                            maxNotes:(int32_t)maxNotes
                          resultSpec:(EDAMNotesMetadataResultSpec *)resultSpec
-                            success:(void(^)(EDAMNotesMetadataList *metadata))success
-                            failure:(void(^)(NSError *error))failure;
+                         completion:(void(^)(EDAMNotesMetadataList *_Nullable metadata, NSError *_Nullable error))completion;
 
 /** This function is used to determine how many notes are found for each notebook and tag in the user's account, given a current set of filter parameters that determine the current selection.
  
@@ -475,15 +371,13 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  
  @param  filter The note selection filter that is currently being applied. The note counts are to be calculated with this filter applied to the total set of notes in the user's account.
  
- @param  withTrash If true, then the NoteCollectionCounts.trashCount will be calculated and supplied in the reply. Otherwise, the trash value will be omitted.
+ @param  includingTrash If true, then the NoteCollectionCounts.trashCount will be calculated and supplied in the reply. Otherwise, the trash value will be omitted.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)findNoteCountsWithFilter:(EDAMNoteFilter *)filter
-                       withTrash:(BOOL)withTrash
-                         success:(void(^)(EDAMNoteCollectionCounts *counts))success
-                         failure:(void(^)(NSError *error))failure;
+                  includingTrash:(BOOL)includingTrash
+                      completion:(void(^)(EDAMNoteCollectionCounts *_Nullable counts, NSError *_Nullable error))completion;
 
 /** Returns the current state of the note in the service with the provided GUID. The ENML contents of the note will only be provided if the 'withContent' parameter is true.
  
@@ -494,99 +388,62 @@ typedef void (^ENNoteStoreClientProgressHandler)(CGFloat progress);
  @param  includingContent If true, the note will include the ENML contents of its 'content' field.
  
  @param  resourceOptions The options for fetching resource data
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchNoteWithGuid:(EDAMGuid)guid
          includingContent:(BOOL)includingContent
           resourceOptions:(ENResourceFetchOption)resourceOptions
-                  success:(void(^)(EDAMNote *note))success
-                  failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteWithGuid:(EDAMGuid)guid
-            withContent:(BOOL)withContent
-      withResourcesData:(BOOL)withResourcesData
-withResourcesRecognition:(BOOL)withResourcesRecognition
-withResourcesAlternateData:(BOOL)withResourcesAlternateData
-                success:(void(^)(EDAMNote *note))success
-                failure:(void(^)(NSError *error))failure
-DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOptions:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+               completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion;
 
 /** Get all of the application data for the note identified by GUID, with values returned within the LazyMap fullMap field.
  
  If there are no applicationData entries, then a LazyMap with an empty fullMap will be returned. If your application only needs to fetch its own applicationData entry, use getNoteApplicationDataEntry instead.
  
  @param  guid The GUID of the note who's application data is to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchNoteApplicationDataWithGuid:(EDAMGuid)guid
-                                 success:(void(^)(EDAMLazyMap *map))success
-                                 failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteApplicationDataWithGuid:(EDAMGuid)guid
-                               success:(void(^)(EDAMLazyMap *map))success
-                               failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteApplicationDataWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                              completion:(void(^)(EDAMLazyMap *_Nullable map, NSError *_Nullable error))completion;
 
 /** Get the value of a single entry in the applicationData map for the note identified by GUID.
  
  @param  guid The GUID of the note
  @param key The key in the dictionary
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
                                           key:(NSString *)key
-                                      success:(void(^)(NSString *entry))success
-                                      failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
-                                        key:(NSString *)key
-                                    success:(void(^)(NSString *entry))success
-                                    failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteApplicationDataEntryWithGuid:key:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                   completion:(void(^)(NSString *_Nullable entry, NSError *_Nullable error))completion;
 
 /** Update, or create, an entry in the applicationData map for the note identified by guid.
  
  @param  guid The GUID of the note
  @param key The key in the dictionary
  @param value The value in the dictionary
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)setNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
                                         key:(NSString *)key
                                       value:(NSString *)value
-                                    success:(void(^)(int32_t usn))success
-                                    failure:(void(^)(NSError *error))failure;
+                                 completion:(void(^)(int32_t usn, NSError *_Nullable error))completion;
 
 /** Remove an entry identified by 'key' from the applicationData map for the note identified by 'guid'. Silently ignores an unset of a non-existing key.
  
  @param  guid The GUID of the note
  @param key key from applicationData map
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)unsetNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
                                           key:(NSString *) key
-                                      success:(void(^)(int32_t usn))success
-                                      failure:(void(^)(NSError *error))failure;
+                                   completion:(void(^)(int32_t usn, NSError *_Nullable error))completion;
 
 /** Returns XHTML contents of the note with the provided GUID. If the Note is found in a public notebook, the authenticationToken will be ignored (so it could be an empty string).
  
  @param  guid The GUID of the note to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchNoteContentWithGuid:(EDAMGuid)guid
-                         success:(void(^)(NSString *content))success
-                         failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteContentWithGuid:(EDAMGuid)guid
-                       success:(void(^)(NSString *content))success
-                       failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteContentWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                      completion:(void(^)(NSString *_Nullable content, NSError *_Nullable error))completion;
 
 /** Returns a block of the extracted plain text contents of the note with the provided GUID.
  
@@ -597,103 +454,72 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  @param  noteOnly If true, this will only return the text extracted from the ENML contents of the note itself. If false, this will also include the extracted text from any text-bearing resources (PDF, recognized images)
  
  @param  tokenizeForIndexing If true, this will break the text into cleanly separated and sanitized tokens. If false, this will return the more raw text extraction, with its original punctuation, capitalization, spacing, etc.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchSearchTextForNoteWithGuid:(EDAMGuid)guid
                               noteOnly:(BOOL)noteOnly
                    tokenizeForIndexing:(BOOL)tokenizeForIndexing
-                               success:(void(^)(NSString *text))success
-                               failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteSearchTextWithGuid:(EDAMGuid)guid
-                         noteOnly:(BOOL)noteOnly
-              tokenizeForIndexing:(BOOL)tokenizeForIndexing
-                          success:(void(^)(NSString *text))success
-                          failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchSearchTextNoteWithGuid:noteOnly:tokenizeForIndexing:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                            completion:(void(^)(NSString *_Nullable text, NSError *_Nullable error))completion;
 
 /** Returns a block of the extracted plain text contents of the resource with the provided GUID.
  
  This text can be indexed for search purposes by a light client that doesn't have capability to extract all of the searchable text content from a resource. If the Resource is found in a public notebook, the authenticationToken will be ignored (so it could be an empty string).
  
  @param  guid The GUID of the resource to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchSearchTextForResourceWithGuid:(EDAMGuid)guid
-                                   success:(void(^)(NSString *text))success
-                                   failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceSearchTextWithGuid:(EDAMGuid)guid
-                              success:(void(^)(NSString *text))success
-                              failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchSearchTextForResourceWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                completion:(void(^)(NSString *_Nullable text, NSError *_Nullable error))completion;
 
 /** Returns a list of the names of the tags for the note with the provided guid.
  
  This can be used with authentication to get the tags for a user's own note, or can be used without valid authentication to retrieve the names of the tags for a note in a public notebook.
  
  @param  guid The GUID of the note.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchTagNamesForNoteWithGuid:(EDAMGuid)guid
-                             success:(void(^)(NSArray<NSString *> *names))success
-                             failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteTagNamesWithGuid:(EDAMGuid)guid
-                        success:(void(^)(NSArray<NSString *> *names))success
-                        failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchTagNamesForNoteWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                          completion:(void(^)(NSArray<NSString *> *_Nullable names, NSError *_Nullable error))completion;
 
 /** Asks the service to make a note with the provided set of information.
  
  @param  note A Note object containing the desired fields to be populated on the service.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  @exception EDAMUserException Thrown if the note is not valid.
  @exception EDAMNotFoundException If the note is not found by GUID
  */
 - (void)createNote:(EDAMNote *)note
-           success:(void(^)(EDAMNote *note))success
-           failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(create(_:success:failure:));
+        completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion NS_SWIFT_NAME(create(_:completion:));
 
 /** Submit a set of changes to a note to the service.
  
  The provided data must include the note's guid field for identification. The note's title must also be set.
  
  @param  note A Note object containing the desired fields to be populated on the service. With the exception of the note's title and guid, fields that are not being changed do not need to be set. If the content is not being modified, note.content should be left unset. If the list of resources is not being modified, note.resources should be left unset.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateNote:(EDAMNote *)note
-           success:(void(^)(EDAMNote *note))success
-           failure:(void(^)(NSError *error))failure;
+        completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion;
 
 /** Moves the note into the trash. The note may still be undeleted, unless it is expunged.
  
  This is equivalent to calling updateNote() after setting Note.active = false
  
  @param  guid The GUID of the note to delete.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)deleteNoteWithGuid:(EDAMGuid)guid
-                   success:(void(^)(int32_t usn))success
-                   failure:(void(^)(NSError *error))failure;
+                completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Permanently removes a Note, and all of its Resources, from the service.
  
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
  @param  guid The GUID of the note to delete.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeNoteWithGuid:(EDAMGuid)guid
-                    success:(void(^)(int32_t usn))success
-                    failure:(void(^)(NSError *error))failure;
+                 completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Permanently removes a list of Notes, and all of their Resources, from the service.
  
@@ -702,12 +528,10 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
  @param  guids The list of GUIDs for the Notes to remove.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeNotesWithGuids:(NSArray<EDAMGuid> *)guids
-                      success:(void(^)(int32_t usn))success
-                      failure:(void(^)(NSError *error))failure;
+                   completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Permanently removes all of the Notes that are currently marked as inactive.
  
@@ -715,11 +539,9 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)expungeInactiveNoteWithSuccess:(void(^)(int32_t usn))success
-                               failure:(void(^)(NSError *error))failure;
+- (void)expungeInactiveNoteWithCompletion:(void(^)(int32_t , NSError *_Nullable error))completion;
 
 /** Performs a deep copy of the Note with the provided GUID 'noteGuid' into the Notebook with the provided GUID 'toNotebookGuid'.
  
@@ -728,31 +550,21 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  @param  guid The GUID of the Note to copy.
  
  @param  notebookGuid The GUID of the Notebook that should receive the new Note.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)copyNoteWithGuid:(EDAMGuid)guid
       toNotebookWithGuid:(EDAMGuid)notebookGuid
-                 success:(void(^)(EDAMNote *note))success
-                 failure:(void(^)(NSError *error))failure;
-
-- (void)copyNoteWithGuid:(EDAMGuid)guid
-          toNoteBookGuid:(EDAMGuid)toNotebookGuid
-                 success:(void(^)(EDAMNote *note))success
-                 failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -copyNoteWithGuid:toNotebookWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+              completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion;
 
 /** Returns a list of the prior versions of a particular note that are saved within the service.
  
  These prior versions are stored to provide a recovery from unintentional removal of content from a note. The identifiers that are returned by this call can be used with getNoteVersion to retrieve the previous note. The identifiers will be listed from the most recent versions to the oldest.
  
  @param  guid The GUID of the Note.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)listNoteVersionsWithGuid:(EDAMGuid)guid
-                         success:(void(^)(NSArray<EDAMNoteVersionId *> *versions))success
-                         failure:(void(^)(NSError *error))failure;
+                      completion:(void(^)(NSArray<EDAMNoteVersionId *> *_Nullable versions, NSError *_Nullable error))completion;
 
 /** This can be used to retrieve a previous version of a Note after it has been updated within the service.
  
@@ -763,23 +575,13 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  @param  updateSequenceNum The USN of the version of the note that is being retrieved
  
  @param  resourceOptions The options for fetching resource data
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchNoteVersionWithGuid:(EDAMGuid)guid
                updateSequenceNum:(int32_t)updateSequenceNum
                  resourceOptions:(ENResourceFetchOption)resourceOptions
-                         success:(void(^)(EDAMNote *note))success
-                         failure:(void(^)(NSError *error))failure;
+                      completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion;
 
-- (void)getNoteVersionWithGuid:(EDAMGuid)guid
-             updateSequenceNum:(int32_t)updateSequenceNum
-             withResourcesData:(BOOL)withResourcesData
-      withResourcesRecognition:(BOOL)withResourcesRecognition
-    withResourcesAlternateData:(BOOL)withResourcesAlternateData
-                       success:(void(^)(EDAMNote *note))success
-                       failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteVersionWithGuid:updateSequenceNum:resourceOptions:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 ///---------------------------------------------------------------------------------------
 /// @name NoteStore resource methods
 ///---------------------------------------------------------------------------------------
@@ -791,110 +593,71 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  @param  guid The GUID of the resource to be retrieved.
 
  @param  options The options for fetching resource data
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchResourceWithGuid:(EDAMGuid)guid
                       options:(ENResourceFetchOption)options
-                      success:(void(^)(EDAMResource *resource))success
-                      failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceWithGuid:(EDAMGuid)guid
-                   withData:(BOOL)withData
-            withRecognition:(BOOL)withRecognition
-             withAttributes:(BOOL)withAttributes
-          withAlternateDate:(BOOL)withAlternateData
-                    success:(void(^)(EDAMResource *resource))success
-                    failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceWithGuid:options:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                   completion:(void(^)(EDAMResource *_Nullable resource, NSError *_Nullable error))completion;
 
 /** Get all of the application data for the Resource identified by GUID, with values returned within the LazyMap fullMap field. If there are no applicationData entries, then a LazyMap with an empty fullMap will be returned. If your application only needs to fetch its own applicationData entry, use getResourceApplicationDataEntry instead.
  
  @param  guid The GUID of the Resource.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchResourceApplicationDataWithGuid:(EDAMGuid)guid
-                                     success:(void(^)(EDAMLazyMap *map))success
-                                     failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceApplicationDataWithGuid:(EDAMGuid)guid
-                                   success:(void(^)(EDAMLazyMap *map))success
-                                   failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceApplicationDataWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                  completion:(void(^)(EDAMLazyMap *_Nullable map, NSError *_Nullable error))completion;
 
 /** Get the value of a single entry in the applicationData map for the Resource identified by GUID.
  
  @param  guid The GUID of the Resource.
  @param key key in the dictionary
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
                                               key:(NSString *)key
-                                          success:(void(^)(NSString *entry))success
-                                          failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(fetchResourceApplicationDataEntryWith(guid:key:success:failure:));
-
-- (void)getResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
-                                            key:(NSString *)key
-                                        success:(void(^)(NSString *entry))success
-                                        failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceApplicationDataWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                       completion:(void(^)(NSString *_Nullable entry, NSError *_Nullable error))completion NS_SWIFT_NAME(fetchResourceApplicationDataEntryWith(guid:key:completion:));;
 
 /** Update, or create, an entry in the applicationData map for the Resource identified by guid.
  
  @param  guid The GUID of the Resource.
  @param key key in the dictionary
  @param value value in the dictionary
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)setResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
                                             key:(NSString *)key
                                           value:(NSString *)value
-                                        success:(void(^)(int32_t usn))success
-                                        failure:(void(^)(NSError *error))failure;
+                                     completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Remove an entry identified by 'key' from the applicationData map for the Resource identified by 'guid'.
  
  @param  guid The GUID of the Resource.
  @param key key in the dictionary
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)unsetResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
                                               key:(NSString *)key
-                                          success:(void(^)(int32_t usn))success
-                                          failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(unsetResourceApplicationDataEntryWith(guid:key:success:failure:));
+                                       completion:(void(^)(int32_t usn , NSError *_Nullable error))completion NS_SWIFT_NAME(unsetResourceApplicationDataEntryWith(guid:key:completion:));
 
 /** Submit a set of changes to a resource to the service.
  
  This can be used to update the meta-data about the resource, but cannot be used to change the binary contents of the resource (including the length and hash). These cannot be changed directly without creating a new resource and removing the old one via updateNote.
  
  @param  resource A Resource object containing the desired fields to be populated on the service. The service will attempt to update the resource with the following fields from the client: guid(must be provided to identify the resource),mime,width,height,duration,attributes(optional. if present, the set of attributes will be replaced).
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateResource:(EDAMResource *)resource
-               success:(void(^)(int32_t usn))success
-               failure:(void(^)(NSError *error))failure;
+            completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Returns binary data of the resource with the provided GUID.
  
  For example, if this were an image resource, this would contain the raw bits of the image. If the Resource is found in a public notebook, the authenticationToken will be ignored (so it could be an empty string).
  
  @param  guid The GUID of the resource to be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchResourceDataWithGuid:(EDAMGuid)guid
-                          success:(void(^)(NSData *data))success
-                          failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceDataWithGuid:(EDAMGuid)guid
-                        success:(void(^)(NSData *data))success
-                        failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceDataWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                       completion:(void(^)(NSData *_Nullable data, NSError *_Nullable error))completion;
 
 /** Returns the current state of a resource, referenced by containing note GUID and resource content hash.
  
@@ -904,23 +667,12 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  
  @param  options The options for fetching resource data
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchResourceByHashWithGuid:(EDAMGuid)guid
                         contentHash:(NSData *)contentHash
                             options:(ENResourceFetchOption)options
-                            success:(void(^)(EDAMResource *resource))success
-                            failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(fetchResourceByHashWith(guid:contentHash:options:success:failure:));
-
-- (void)getResourceByHashWithGuid:(EDAMGuid)guid
-                      contentHash:(NSData *)contentHash
-                         withData:(BOOL)withData
-                  withRecognition:(BOOL)withRecognition
-                withAlternateData:(BOOL)withAlternateData
-                          success:(void(^)(EDAMResource *resource))success
-                          failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourcebyHashWithGuid:contentHash:options:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                         completion:(void(^)(EDAMResource *_Nullable resource, NSError *_Nullable error))completion NS_SWIFT_NAME(fetchResourceByHashWith(guid:contentHash:options:completion:));
 
 
 /** Returns the binary contents of the recognition index for the resource with the provided GUID.
@@ -928,47 +680,26 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  If the caller asks about a resource that has no recognition data, this will throw EDAMNotFoundException. If the Resource is found in a public notebook, the authenticationToken will be ignored (so it could be an empty string).
  
  @param  guid The GUID of the resource whose recognition data should be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchRecognitionDataForResourceWithGuid:(EDAMGuid)guid
-                                        success:(void(^)(NSData *data))success
-                                        failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceRecognitionWithGuid:(EDAMGuid)guid
-                               success:(void(^)(NSData *data))success
-                               failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchRecognitionDataForResourceWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                        completion:(void(^)(NSData *_Nullable data, NSError *_Nullable error))completion;
 
 /** If the Resource with the provided GUID has an alternate data representation (indicated via the Resource.alternateData field), then this request can be used to retrieve the binary contents of that alternate data file. If the caller asks about a resource that has no alternate data form, this will throw EDAMNotFoundException.
  
  @param  guid The GUID of the resource whose recognition data should be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchAlternateDataForResourceWithGuid:(EDAMGuid)guid
-                                      success:(void(^)(NSData *data))success
-                                      failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceAlternateDataWithGuid:(EDAMGuid)guid
-                                 success:(void(^)(NSData *data))success
-                                 failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchAlternateDataForResourceWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                   completion:(void(^)(NSData *_Nullable data, NSError *_Nullable error))completion;
 
 /** Returns the set of attributes for the Resource with the provided GUID. If the Resource is found in a public notebook, the authenticationToken will be ignored (so it could be an empty string).
  
  @param  guid The GUID of the resource whose attributes should be retrieved.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchAttributesForResourceWithGuid:(EDAMGuid)guid
-                                   success:(void(^)(EDAMResourceAttributes *attributes))success
-                                   failure:(void(^)(NSError *error))failure;
-
-- (void)getResourceAttributesWithGuid:(EDAMGuid)guid
-                              success:(void(^)(EDAMResourceAttributes *attributes))success
-                              failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchAttributesForResourceWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                completion:(void(^)(EDAMResourceAttributes *_Nullable attributes, NSError *_Nullable error))completion;
 
 ///---------------------------------------------------------------------------------------
 /// @name NoteStore shared notebook methods
@@ -980,29 +711,19 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  
  @param  userId The numeric identifier for the user who owns the public notebook. To find this value based on a username string, you can invoke UserStore.getPublicUserInfo
  @param  publicURI The uri string for the public notebook, from Notebook.publishing.uri.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchPublicNotebookWithUserID:(EDAMUserID)userId
                             publicURI:(NSString *)publicURI
-                              success:(void(^)(EDAMNotebook *notebook))success
-                              failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(fetchPublicNotebookWith(userID:publicURI:success:failure:));
-
-- (void)getPublicNotebookWithUserID:(EDAMUserID)userId
-                          publicUri:(NSString *)publicUri
-                            success:(void(^)(EDAMNotebook *notebook))success
-                            failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchPublicNotebookWithUserID:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                           completion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion NS_SWIFT_NAME(fetchPublicNotebookWith(userID:publicURI:completion:));
 
 /** Used to construct a shared notebook object. The constructed notebook will contain a "share key" which serve as a unique identifer and access token for a user to access the notebook of the shared notebook owner.
  
  @param  sharedNotebook An shared notebook object populated with the email address of the share recipient, the notebook guid and the access permissions. All other attributes of the shared object are ignored.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)createSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
-                     success:(void(^)(EDAMSharedNotebook *sharedNotebook))success
-                     failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(create(_:success:failure:));
+                  completion:(void(^)(EDAMSharedNotebook *_Nullable sharedNotebook, NSError *_Nullable error))completion NS_SWIFT_NAME(create(_:completion:));
 
 /** Send a reminder message to some or all of the email addresses that a notebook has been shared with.
  
@@ -1011,140 +732,106 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  @param  guid The guid of the shared notebook
  @param  messageText User provided text to include in the email
  @param  recipients The email addresses of the recipients. If this list is empty then all of the users that the notebook has been shared with are emailed. If an email address doesn't correspond to share invite members then that address is ignored.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)sendMessageToMembersOfSharedNotebookWithGuid:(EDAMGuid)guid
                                          messageText:(NSString *)messageText
                                           recipients:(NSArray<NSString *> *)recipients
-                                             success:(void(^)(int32_t numMessagesSent))success
-                                             failure:(void(^)(NSError *error))failure;
-
-- (void)sendMessageToSharedNotebookMembersWithGuid:(EDAMGuid)guid
-                                       messageText:(NSString *)messageText
-                                        recipients:(NSArray<NSString *> *)recipients
-                                           success:(void(^)(int32_t numMessagesSent))success
-                                           failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -senderMessageToMembersOfSharedNotebookWithGuid:messageText:recipients:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                                          completion:(void(^)(int32_t numMessagesSent , NSError *_Nullable error))completion;
 
 /** Lists the collection of shared notebooks for all notebooks in the users account.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)listSharedNotebooksWithSuccess:(void(^)(NSArray<EDAMSharedNotebook *> *sharedNotebooks))success
-                               failure:(void(^)(NSError *error))failure;
+- (void)listSharedNotebooksWithCompletion:(void(^)(NSArray<EDAMSharedNotebook *> *_Nullable sharedNotebooks, NSError *_Nullable error))completion;
 
 /** Expunges the SharedNotebooks in the user's account using the SharedNotebook.id as the identifier.
  
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
  @param sharedNotebookIds a list of ShardNotebook.id longs identifying the objects to delete permanently.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeSharedNotebooksWithIds:(NSArray<NSNumber *> *)sharedNotebookIds
-                              success:(void(^)(int32_t usn))success
-                              failure:(void(^)(NSError *error))failure;
+                           completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Asks the service to make a linked notebook with the provided name, username of the owner and identifiers provided.
  
  A linked notebook can be either a link to a public notebook or to a private shared notebook.
  
  @param  linkedNotebook The desired fields for the linked notebook must be provided on this object. The name of the linked notebook must be set. Either a username uri or a shard id and share key must be provided otherwise a EDAMUserException is thrown.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)createLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
-                     success:(void(^)(EDAMLinkedNotebook *linkedNotebook))success
-                     failure:(void(^)(NSError *error))failure NS_SWIFT_NAME(create(_:success:failure:));
+                  completion:(void(^)(EDAMLinkedNotebook *_Nullable linkedNotebook, NSError *_Nullable error))completion NS_SWIFT_NAME(create(_:completion:));
 
 /** Asks the service to update a linked notebook.
  
  @param  linkedNotebook Updates the name of a linked notebook.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
-                     success:(void(^)(int32_t usn))success
-                     failure:(void(^)(NSError *error))failure;
+                  completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Returns a list of linked notebooks
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)listLinkedNotebooksWithSuccess:(void(^)(NSArray<EDAMLinkedNotebook *> *linkedNotebooks))success
-                               failure:(void(^)(NSError *error))failure;
+- (void)listLinkedNotebooksWithCompletion:(void(^)(NSArray<EDAMLinkedNotebook *> *_Nullable linkedNotebooks, NSError *_Nullable error))completion;
 
 /** Permanently expunges the linked notebook from the account.
  
  NOTE: This function is not available to third party applications. Calls will result in an EDAMUserException with the error code PERMISSION_DENIED.
  
  @param  guid The LinkedNotebook.guid field of the LinkedNotebook to permanently remove from the account.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)expungeLinkedNotebookWithGuid:(EDAMGuid)guid
-                              success:(void(^)(int32_t usn))success
-                              failure:(void(^)(NSError *error))failure;
+                           completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Asks the service to produce an authentication token that can be used to access the contents of a shared notebook from someone else's account.
  
  This authenticationToken can be used with the various other NoteStore calls to find and retrieve notes, and if the permissions in the shared notebook are sufficient, to make changes to the contents of the notebook.
  
  @param  shareKeyOrGlobalId The 'shareKey' (or 'globalId') identifier from the SharedNotebook that was granted to some recipient. This string internally encodes the notebook identifier and a security signature.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)authenticateToSharedNotebook:(NSString *)shareKeyOrGlobalId
-                             success:(void(^)(EDAMAuthenticationResult *result))success
-                             failure:(void(^)(NSError *error))failure;
+                             completion:(void(^)(EDAMAuthenticationResult *_Nullable result, NSError *_Nullable error))completion;
 
 /** This function is used to retrieve extended information about a shared notebook by a guest who has already authenticated to access that notebook.
  
  This requires an 'authenticationToken' parameter which should be the resut of a call to authenticateToSharedNotebook(...). I.e. this is the token that gives access to the particular shared notebook in someone else's account -- it's not the authenticationToken for the owner of the notebook itself.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)fetchSharedNotebookByAuthWithSuccess:(void(^)(EDAMSharedNotebook *sharedNotebook))success
-                                     failure:(void(^)(NSError *error))failure;
-
-- (void)getSharedNotebookByAuthWithSuccess:(void(^)(EDAMSharedNotebook *sharedNotebook))success
-                                   failure:(void(^)(NSError *error))failure;
+- (void)fetchSharedNotebookByAuthWithCompletion:(void(^)(EDAMSharedNotebook *_Nullable sharedNotebook, NSError *_Nullable error))completion;
 
 /** Attempts to send a single note to one or more email recipients.
  
  @param  parameters The note must be specified either by GUID (in which case it will be sent using the existing data in the service), or else the full Note must be passed to this call. This also specifies the additional email fields that will be used in the email.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)emailNoteWithParameters:(EDAMNoteEmailParameters *)parameters
-                        success:(void(^)())success
-                        failure:(void(^)(NSError *error))failure;
+                     completion:(void(^)(NSError *error))completion;
 
 /** If this note is not already shared (via its own direct URL), then this will start sharing that note.
  
  This will return the secret "Note Key" for this note that can currently be used in conjunction with the Note's GUID to gain direct read-only access to the Note. If the note is already shared, then this won't make any changes to the note, and the existing "Note Key" will be returned. The only way to change the Note Key for an existing note is to stopSharingNote first, and then call this function.
  
  @param  guid The GUID of the note to be shared.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)shareNoteWithGuid:(EDAMGuid)guid
-                  success:(void(^)(NSString *noteKey))success
-                  failure:(void(^)(NSError *error))failure;
+               completion:(void(^)(NSString *_Nullable noteKey, NSError *_Nullable error))completion;
 
 /** If this note is not already shared then this will stop sharing that note and invalidate its "Note Key", so any existing URLs to access that Note will stop working. If the Note is not shared, then this function will do nothing.
  
  @param  guid The GUID of the note to be un-shared.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)stopSharingNoteWithGuid:(EDAMGuid)guid
-                        success:(void(^)())success
-                        failure:(void(^)(NSError *error))failure;
+                     completion:(void(^)(NSError *error))completion;
 
 /** Asks the service to produce an authentication token that can be used to access the contents of a single Note which was individually shared from someone's account.
  
@@ -1153,47 +840,455 @@ DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOption
  @param  guid The GUID identifying this Note on this shard.
  @param  noteKey The 'noteKey' identifier from the Note that was originally created via a call to shareNote() and then given to a recipient to access.
  @param authenticationToken Optional, only required for Yinxiang
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)authenticateToSharedNoteWithGuid:(NSString *)guid
                                  noteKey:(NSString *)noteKey
                      authenticationToken:(nullable NSString*)authenticationToken
-                                 success:(void(^)(EDAMAuthenticationResult *result))success
-                                 failure:(void(^)(NSError *error))failure;
+                              completion:(void(^)(EDAMAuthenticationResult *_Nullable result, NSError *_Nullable error))completion;
 
 /** Update a SharedNotebook object.
  
  @param  sharedNotebook The SharedNotebook object containing the requested changes. The "id" of the shared notebook must be set to allow the service to identify the SharedNotebook to be updated. In addition, you MUST set the email, permission, and allowPreview fields to the desired values. All other fields will be ignored if set.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)updateSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
-                     success:(void(^)(int32_t usn))success
-                     failure:(void(^)(NSError *error))failure;
+                  completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /** Set shared notebook recipient settings.
  
  @param sharedNotebookId The shared notebooks id
  @param recipientSettings The settings of the recipient
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)setRecipientSettings:(EDAMSharedNotebookRecipientSettings *) recipientSettings
      forSharedNotebookWithID:(int64_t)sharedNotebookId
-                     success:(void(^)(int32_t usn))success
-                     failure:(void(^)(NSError *error))failure;
-
-- (void) setSharedNotebookRecipientSettingsWithSharedNotebookId: (int64_t) sharedNotebookId
-                                              recipientSettings: (EDAMSharedNotebookRecipientSettings *) recipientSettings
-                                                        success:(void(^)(int32_t usn))success
-                                                        failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -setRecipientSettings:forSharedNotebookWithID:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                  completion:(void(^)(int32_t usn , NSError *_Nullable error))completion;
 
 /**
  *  Cancel the first operation on the note store queue
  */
 - (void) cancelFirstOperation;
+
+@end
+
+
+
+
+//Deprecated
+@interface ENNoteStoreClient ()
+
+- (void)getSyncStateWithSuccess:(void(^)(EDAMSyncState *syncState))success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncStateWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getSyncChunkAfterUSN:(int32_t)afterUSN
+                  maxEntries:(int32_t)maxEntries
+                fullSyncOnly:(BOOL)fullSyncOnly
+                     success:(void(^)(EDAMSyncChunk *syncChunk))success
+                     failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncChunkAfterUSN:maxEntries:fullSyncOnly:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getFilteredSyncChunkAfterUSN:(int32_t)afterUSN
+                          maxEntries:(int32_t)maxEntries
+                              filter:(EDAMSyncChunkFilter *)filter
+                             success:(void(^)(EDAMSyncChunk *syncChunk))success
+                             failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchFilteredSyncChunkAfterUSN:maxEntries:filter:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getLinkedNotebookSyncState:(EDAMLinkedNotebook *)linkedNotebook
+                           success:(void(^)(EDAMSyncState *syncState))success
+                           failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncStateForLinkedNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getLinkedNotebookSyncChunk:(EDAMLinkedNotebook *)linkedNotebook
+                          afterUSN:(int32_t)afterUSN
+                        maxEntries:(int32_t)maxEntries
+                      fullSyncOnly:(BOOL)fullSyncOnly
+                           success:(void(^)(EDAMSyncChunk *syncChunk))success
+                           failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSyncChunkForLinkedNotebook:afterUSN:maxEntries:fullSyncOnly:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listNotebooksWithSuccess:(void(^)(NSArray<EDAMNotebook *> *notebooks))success
+                         failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listNotebooksWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNotebookWithGuid:(EDAMGuid)guid
+                    success:(void(^)(EDAMNotebook *notebook))success
+                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchNotebookWithGuid:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getDefaultNotebookWithSuccess:(void(^)(EDAMNotebook *notebook))success
+                              failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchDefaultNotebookWithSuccess:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)createNotebook:(EDAMNotebook *)notebook
+               success:(void(^)(EDAMNotebook *notebook))success
+               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -createNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateNotebook:(EDAMNotebook *)notebook
+               success:(void(^)(int32_t usn))success
+               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeNotebookWithGuid:(EDAMGuid)guid
+                        success:(void(^)(int32_t usn))success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeNotebookWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listTagsWithSuccess:(void(^)(NSArray<EDAMTag *> *tags))success
+                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listTagsWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listTagsByNotebookWithGuid:(EDAMGuid)guid
+                           success:(void(^)(NSArray<EDAMTag *> *tags))success
+                           failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listTagsInNotebookWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getTagWithGuid:(EDAMGuid)guid
+               success:(void(^)(EDAMTag *tag))success
+               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchTagWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)createTag:(EDAMTag *)tag
+          success:(void(^)(EDAMTag *tag))success
+          failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -createTag:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateTag:(EDAMTag *)tag
+          success:(void(^)(int32_t usn))success
+          failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateTag:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)untagAllWithGuid:(EDAMGuid)guid
+                 success:(void(^)())success
+                 failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -untagAllWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeTagWithGuid:(EDAMGuid)guid
+                   success:(void(^)(int32_t usn))success
+                   failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeTagWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listSearchesWithSuccess:(void(^)(NSArray<EDAMSavedSearch *> *searches))success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listSearchesWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getSearchWithGuid:(EDAMGuid)guid
+                  success:(void(^)(EDAMSavedSearch *search))success
+                  failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSearchWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)createSearch:(EDAMSavedSearch *)search
+             success:(void(^)(EDAMSavedSearch *search))success
+             failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -createSearch:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateSearch:(EDAMSavedSearch *)search
+             success:(void(^)(int32_t usn))success
+             failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateSearch:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeSearchWithGuid:(EDAMGuid)guid
+                      success:(void(^)(int32_t usn))success
+                      failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeSearchWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)findRelatedWithQuery:(EDAMRelatedQuery *)query
+                  resultSpec:(EDAMRelatedResultSpec *)resultSpec
+                     success:(void(^)(EDAMRelatedResult *result))success
+                     failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -findRelatedWithQuery:resultSpect:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)findNotesWithFilter:(EDAMNoteFilter *)filter
+                     offset:(int32_t)offset
+                   maxNotes:(int32_t)maxNotes
+                    success:(void(^)(EDAMNoteList *list))success
+                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -findNotesWithFilter:offset:maxNotes:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)findNoteOffsetWithFilter:(EDAMNoteFilter *)filter
+                            guid:(EDAMGuid)guid
+                         success:(void(^)(int32_t offset))success
+                         failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -findNoteOffsetWithFilter:guid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)findNotesMetadataWithFilter:(EDAMNoteFilter *)filter
+                             offset:(int32_t)offset
+                           maxNotes:(int32_t)maxNotes
+                         resultSpec:(EDAMNotesMetadataResultSpec *)resultSpec
+                            success:(void(^)(EDAMNotesMetadataList *metadata))success
+                            failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -findNotesMetadataWithFilter:offset:maxNotes:resultSpec:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+
+- (void)findNoteCountsWithFilter:(EDAMNoteFilter *)filter
+                       withTrash:(BOOL)withTrash
+                         success:(void(^)(EDAMNoteCollectionCounts *counts))success
+                         failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -findNoteCountsWithFilter:includingTrash:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteWithGuid:(EDAMGuid)guid
+            withContent:(BOOL)withContent
+      withResourcesData:(BOOL)withResourcesData
+withResourcesRecognition:(BOOL)withResourcesRecognition
+withResourcesAlternateData:(BOOL)withResourcesAlternateData
+                success:(void(^)(EDAMNote *note))success
+                failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteWithGuid:includingContent:resourceOptions:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteApplicationDataWithGuid:(EDAMGuid)guid
+                               success:(void(^)(EDAMLazyMap *map))success
+                               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteApplicationDataWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                        key:(NSString *)key
+                                    success:(void(^)(NSString *entry))success
+                                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteApplicationDataEntryWithGuid:key:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)setNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                        key:(NSString *)key
+                                      value:(NSString *)value
+                                    success:(void(^)(int32_t usn))success
+                                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -setNoteApplicationDataEntryWithGuid:key:value:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)unsetNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                          key:(NSString *) key
+                                      success:(void(^)(int32_t usn))success
+                                      failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -unsetNoteApplicationDataEntryWithGuid:key:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteContentWithGuid:(EDAMGuid)guid
+                       success:(void(^)(NSString *content))success
+                       failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteContentWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteSearchTextWithGuid:(EDAMGuid)guid
+                         noteOnly:(BOOL)noteOnly
+              tokenizeForIndexing:(BOOL)tokenizeForIndexing
+                          success:(void(^)(NSString *text))success
+                          failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSearchTextNoteWithGuid:noteOnly:tokenizeForIndexing:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceSearchTextWithGuid:(EDAMGuid)guid
+                              success:(void(^)(NSString *text))success
+                              failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchSearchTextForResourceWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteTagNamesWithGuid:(EDAMGuid)guid
+                        success:(void(^)(NSArray<NSString *> *names))success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchTagNamesForNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)createNote:(EDAMNote *)note
+           success:(void(^)(EDAMNote *note))success
+           failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -createNote:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateNote:(EDAMNote *)note
+           success:(void(^)(EDAMNote *note))success
+           failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateNote:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)deleteNoteWithGuid:(EDAMGuid)guid
+                   success:(void(^)(int32_t usn))success
+                   failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -deleteNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeNoteWithGuid:(EDAMGuid)guid
+                    success:(void(^)(int32_t usn))success
+                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeNotesWithGuids:(NSArray<EDAMGuid> *)guids
+                      success:(void(^)(int32_t usn))success
+                      failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeNotesWithGuids:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeInactiveNoteWithSuccess:(void(^)(int32_t usn))success
+                               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeInactiveNoteWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)copyNoteWithGuid:(EDAMGuid)guid
+          toNoteBookGuid:(EDAMGuid)toNotebookGuid
+                 success:(void(^)(EDAMNote *note))success
+                 failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -copyNoteWithGuid:toNotebookWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listNoteVersionsWithGuid:(EDAMGuid)guid
+                         success:(void(^)(NSArray<EDAMNoteVersionId *> *versions))success
+                         failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listNoteVersionsWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteVersionWithGuid:(EDAMGuid)guid
+             updateSequenceNum:(int32_t)updateSequenceNum
+             withResourcesData:(BOOL)withResourcesData
+      withResourcesRecognition:(BOOL)withResourcesRecognition
+    withResourcesAlternateData:(BOOL)withResourcesAlternateData
+                       success:(void(^)(EDAMNote *note))success
+                       failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteVersionWithGuid:updateSequenceNum:resourceOptions:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceWithGuid:(EDAMGuid)guid
+                   withData:(BOOL)withData
+            withRecognition:(BOOL)withRecognition
+             withAttributes:(BOOL)withAttributes
+          withAlternateDate:(BOOL)withAlternateData
+                    success:(void(^)(EDAMResource *resource))success
+                    failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceWithGuid:options:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceApplicationDataWithGuid:(EDAMGuid)guid
+                                   success:(void(^)(EDAMLazyMap *map))success
+                                   failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceApplicationDataWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                            key:(NSString *)key
+                                        success:(void(^)(NSString *entry))success
+                                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceApplicationDataWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)setResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                            key:(NSString *)key
+                                          value:(NSString *)value
+                                        success:(void(^)(int32_t usn))success
+                                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -setResourceApplicationDataEntryWithGuid:key:value:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)unsetResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                              key:(NSString *)key
+                                          success:(void(^)(int32_t usn))success
+                                          failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -unsetResourceApplicationDataEntryWithGuid:key:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateResource:(EDAMResource *)resource
+               success:(void(^)(int32_t usn))success
+               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateResource:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceDataWithGuid:(EDAMGuid)guid
+                        success:(void(^)(NSData *data))success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourceDataWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceByHashWithGuid:(EDAMGuid)guid
+                      contentHash:(NSData *)contentHash
+                         withData:(BOOL)withData
+                  withRecognition:(BOOL)withRecognition
+                withAlternateData:(BOOL)withAlternateData
+                          success:(void(^)(EDAMResource *resource))success
+                          failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchResourcebyHashWithGuid:contentHash:options:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceRecognitionWithGuid:(EDAMGuid)guid
+                               success:(void(^)(NSData *data))success
+                               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchRecognitionDataForResourceWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceAlternateDataWithGuid:(EDAMGuid)guid
+                                 success:(void(^)(NSData *data))success
+                                 failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchAlternateDataForResourceWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getResourceAttributesWithGuid:(EDAMGuid)guid
+                              success:(void(^)(EDAMResourceAttributes *attributes))success
+                              failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchAttributesForResourceWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getPublicNotebookWithUserID:(EDAMUserID)userId
+                          publicUri:(NSString *)publicUri
+                            success:(void(^)(EDAMNotebook *notebook))success
+                            failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -fetchPublicNotebookWithUserID:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)createSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
+                     success:(void(^)(EDAMSharedNotebook *sharedNotebook))success
+                     failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -createSharedNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)sendMessageToSharedNotebookMembersWithGuid:(EDAMGuid)guid
+                                       messageText:(NSString *)messageText
+                                        recipients:(NSArray<NSString *> *)recipients
+                                           success:(void(^)(int32_t numMessagesSent))success
+                                           failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -senderMessageToMembersOfSharedNotebookWithGuid:messageText:recipients:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listSharedNotebooksWithSuccess:(void(^)(NSArray<EDAMSharedNotebook *> *sharedNotebooks))success
+                               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listSharedNotebooksWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeSharedNotebooksWithIds:(NSArray<NSNumber *> *)sharedNotebookIds
+                              success:(void(^)(int32_t usn))success
+                              failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeSharedNotebooksWithIds:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)createLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
+                     success:(void(^)(EDAMLinkedNotebook *linkedNotebook))success
+                     failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -createLinkedNotebook:completion instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
+                     success:(void(^)(int32_t usn))success
+                     failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateLinkedNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)listLinkedNotebooksWithSuccess:(void(^)(NSArray<EDAMLinkedNotebook *> *linkedNotebooks))success
+                               failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -listLinkedNotebooksWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)expungeLinkedNotebookWithGuid:(EDAMGuid)guid
+                              success:(void(^)(int32_t usn))success
+                              failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -expungeLinkedNotebookWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)authenticateToSharedNotebook:(NSString *)shareKeyOrGlobalId
+                             success:(void(^)(EDAMAuthenticationResult *result))success
+                             failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -authenticateToSharedNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getSharedNotebookByAuthWithSuccess:(void(^)(EDAMSharedNotebook *sharedNotebook))success
+                                   failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -getSharedNotebookByAuthWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)emailNoteWithParameters:(EDAMNoteEmailParameters *)parameters
+                        success:(void(^)())success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -emailNoteWithParameters:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)shareNoteWithGuid:(EDAMGuid)guid
+                  success:(void(^)(NSString *noteKey))success
+                  failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -shareNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)stopSharingNoteWithGuid:(EDAMGuid)guid
+                        success:(void(^)())success
+                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -stopSharingNoteWithGuid:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)authenticateToSharedNoteWithGuid:(NSString *)guid
+                                 noteKey:(NSString *)noteKey
+                     authenticationToken:(nullable NSString*)authenticationToken
+                                 success:(void(^)(EDAMAuthenticationResult *result))success
+                                 failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -authenticateToSharedNotebookWithGuid:noteKey:authenticationToken:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)updateSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
+                     success:(void(^)(int32_t usn))success
+                     failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -updateSharedNotebook:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void) setSharedNotebookRecipientSettingsWithSharedNotebookId: (int64_t) sharedNotebookId
+                                              recipientSettings: (EDAMSharedNotebookRecipientSettings *) recipientSettings
+                                                        success:(void(^)(int32_t usn))success
+                                                        failure:(void(^)(NSError *error))failure
+DEPRECATED_MSG_ATTRIBUTE("Use -setRecipientSettings:forSharedNotebookWithID:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+
 
 @end
 

--- a/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENNoteStoreClient.m
@@ -136,739 +136,668 @@
 
 #pragma mark - NoteStore sync methods
 
-- (void)fetchSyncStateWithSuccess:(void(^)(EDAMSyncState *syncState))success
-                          failure:(void(^)(NSError *error))failure
+- (void)fetchSyncStateWithCompletion:(void(^)(EDAMSyncState *syncState, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getSyncState:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchSyncChunkAfterUSN:(int32_t)afterUSN
                     maxEntries:(int32_t)maxEntries
                   fullSyncOnly:(BOOL)fullSyncOnly
-                       success:(void(^)(EDAMSyncChunk *syncChunk))success
-                       failure:(void(^)(NSError *error))failure
+                    completion:(void(^)(EDAMSyncChunk *_Nullable syncChunk, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getSyncChunk:self.authenticationToken afterUSN:afterUSN maxEntries:maxEntries fullSyncOnly:fullSyncOnly];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchFilteredSyncChunkAfterUSN:(int32_t)afterUSN
                             maxEntries:(int32_t)maxEntries
                                 filter:(EDAMSyncChunkFilter *)filter
-                               success:(void(^)(EDAMSyncChunk *syncChunk))success
-                               failure:(void(^)(NSError *error))failure
+                            completion:(void(^)(EDAMSyncChunk *_Nullable syncChunk, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getFilteredSyncChunk:self.authenticationToken afterUSN:afterUSN maxEntries:maxEntries filter:filter];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchSyncStateForLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
-                                success:(void(^)(EDAMSyncState *syncState))success
-                                failure:(void(^)(NSError *error))failure
+                             completion:(void(^)(EDAMSyncState *_Nullable syncState, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getLinkedNotebookSyncState:self.authenticationToken linkedNotebook:linkedNotebook];
-    } success:success failure:failure];
-}
-
-#pragma mark - NoteStore notebook methods
-
-- (void)listNotebooksWithSuccess:(void(^)(NSArray<EDAMNotebook *> *notebooks))success
-                         failure:(void(^)(NSError *error))failure
-{
-    [self invokeAsyncIdBlock:^id {
-        return [self.client listNotebooks:self.authenticationToken];
-    } success:success failure:failure];
-}
-
-- (void)fetchNotebookWithGuid:(EDAMGuid)guid
-                      success:(void(^)(EDAMNotebook *notebook))success
-                      failure:(void(^)(NSError *error))failure
-{
-    [self invokeAsyncIdBlock:^id {
-        return [self.client getNotebook:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchSyncChunkForLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
                                afterUSN:(int32_t)afterUSN
-                             maxEntries:(int32_t) maxEntries
+                             maxEntries:(int32_t)maxEntries
                            fullSyncOnly:(BOOL)fullSyncOnly
-                                success:(void(^)(EDAMSyncChunk *syncChunk))success
-                                failure:(void(^)(NSError *error))failure
+                             completion:(void(^)(EDAMSyncChunk *_Nullable syncChunk, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getLinkedNotebookSyncChunk:self.authenticationToken linkedNotebook:linkedNotebook afterUSN:afterUSN maxEntries:maxEntries fullSyncOnly:fullSyncOnly];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)fetchDefaultNotebookWithSuccess:(void(^)(EDAMNotebook *notebook))success
-                                failure:(void(^)(NSError *error))failure
+#pragma mark - NoteStore notebook methods
+
+- (void)listNotebooksWithCompletion:(void(^)(NSArray<EDAMNotebook *> *_Nullable notebooks, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
+        return [self.client listNotebooks:self.authenticationToken];
+    } completion:completion];
+}
+
+- (void)fetchNotebookWithGuid:(EDAMGuid)guid
+                   completion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion
+{
+    [self invokeAsyncObjectBlock:^id {
+        return [self.client getNotebook:self.authenticationToken guid:guid];
+    } completion:completion];
+}
+
+
+
+- (void)fetchDefaultNotebookWithCompletion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion
+{
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getDefaultNotebook:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)createNotebook:(EDAMNotebook *)notebook
-               success:(void(^)(EDAMNotebook *notebook))success
-               failure:(void(^)(NSError *error))failure
+            completion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion
 {
     [[ENSession sharedSession] listNotebooks_cleanCache];
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client createNotebook:self.authenticationToken notebook:notebook];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateNotebook:(EDAMNotebook *)notebook
-               success:(void(^)(int32_t usn))success
-               failure:(void(^)(NSError *error))failure
+            completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client updateNotebook:self.authenticationToken notebook:notebook];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeNotebookWithGuid:(EDAMGuid)guid
-                        success:(void(^)(int32_t usn))success
-                        failure:(void(^)(NSError *error))failure
+                     completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeNotebook:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 #pragma mark - NoteStore tags methods
 
-- (void)listTagsWithSuccess:(void(^)(NSArray<EDAMTag *> *tags))success
-                    failure:(void(^)(NSError *error))failure
+- (void)listTagsWithCompletion:(void(^)(NSArray<EDAMTag *> *_Nullable tags, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client listTags:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)listTagsInNotebookWithGuid:(EDAMGuid)guid
-                           success:(void(^)(NSArray<EDAMTag *> *tags))success
-                           failure:(void(^)(NSError *error))failure
+                        completion:(void(^)(NSArray<EDAMTag *> * _Nullable tags, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client listTagsByNotebook:self.authenticationToken notebookGuid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 };
 
 - (void)fetchTagWithGuid:(EDAMGuid)guid
-                 success:(void(^)(EDAMTag *tag))success
-                 failure:(void(^)(NSError *error))failure
+              completion:(void(^)(EDAMTag *_Nullable tag, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getTag:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)createTag:(EDAMTag *)tag
-          success:(void(^)(EDAMTag *tag))success
-          failure:(void(^)(NSError *error))failure
+       completion:(void(^)(EDAMTag *_Nullable tag, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client createTag:self.authenticationToken tag:tag];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateTag:(EDAMTag *)tag
-          success:(void(^)(int32_t usn))success
-          failure:(void(^)(NSError *error))failure
+       completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client updateTag:self.authenticationToken tag:tag];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)untagAllWithGuid:(EDAMGuid)guid
-                 success:(void(^)())success
-                 failure:(void(^)(NSError *error))failure
+              completion:(void(^)(NSError *error))completion
 {
-    [self invokeAsyncVoidBlock:^ {
+    [self invokeAsyncBlock:^ {
         [self.client untagAll:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeTagWithGuid:(EDAMGuid)guid
-                   success:(void(^)(int32_t usn))success
-                   failure:(void(^)(NSError *error))failure
+                completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeTag:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 #pragma mark - NoteStore search methods
 
-- (void)listSearchesWithSuccess:(void(^)(NSArray<EDAMSavedSearch *> *searches))success
-                        failure:(void(^)(NSError *error))failure
+- (void)listSearchesWithCompletion:(void(^)(NSArray<EDAMSavedSearch *> *_Nullable searches, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client listSearches:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchSearchWithGuid:(EDAMGuid)guid
-                    success:(void(^)(EDAMSavedSearch *search))success
-                    failure:(void(^)(NSError *error))failure
+                 completion:(void(^)(EDAMSavedSearch *_Nullable search, NSError *_Nullable error))completion
 
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getSearch:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)createSearch:(EDAMSavedSearch *)search
-             success:(void(^)(EDAMSavedSearch *search))success
-             failure:(void(^)(NSError *error))failure
+          completion:(void(^)(EDAMSavedSearch *_Nullable search, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client createSearch:self.authenticationToken search:search];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateSearch:(EDAMSavedSearch *)search
-             success:(void(^)(int32_t usn))success
-             failure:(void(^)(NSError *error))failure
+          completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client updateSearch:self.authenticationToken search:search];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeSearchWithGuid:(EDAMGuid)guid
-                      success:(void(^)(int32_t usn))success
-                      failure:(void(^)(NSError *error))failure
+                   completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeSearch:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 #pragma mark - NoteStore notes methods
 - (void)findRelatedWithQuery:(EDAMRelatedQuery *)query
                   resultSpec:(EDAMRelatedResultSpec *)resultSpec
-                     success:(void(^)(EDAMRelatedResult *result))success
-                     failure:(void(^)(NSError *error))failure
+                  completion:(void(^)(EDAMRelatedResult *_Nullable result, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client findRelated:self.authenticationToken query:query resultSpec:resultSpec];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)findNotesWithFilter:(EDAMNoteFilter *)filter
                      offset:(int32_t)offset
                    maxNotes:(int32_t)maxNotes
-                    success:(void(^)(EDAMNoteList *list))success
-                    failure:(void(^)(NSError *error))failure
+                 completion:(void(^)(EDAMNoteList *_Nullable list, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client findNotes:self.authenticationToken filter:filter offset:offset maxNotes:maxNotes];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)findNoteOffsetWithFilter:(EDAMNoteFilter *)filter
                             guid:(EDAMGuid)guid
-                         success:(void(^)(int32_t offset))success
-                         failure:(void(^)(NSError *error))failure
+                      completion:(void(^)(int32_t offset , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client findNoteOffset:self.authenticationToken filter:filter guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)findNotesMetadataWithFilter:(EDAMNoteFilter *)filter
                              offset:(int32_t)offset
                            maxNotes:(int32_t)maxNotes
                          resultSpec:(EDAMNotesMetadataResultSpec *)resultSpec
-                            success:(void(^)(EDAMNotesMetadataList *metadata))success
-                            failure:(void(^)(NSError *error))failure
+                         completion:(void(^)(EDAMNotesMetadataList *_Nullable metadata, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client findNotesMetadata:self.authenticationToken filter:filter offset:offset maxNotes:maxNotes resultSpec:resultSpec];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)findNoteCountsWithFilter:(EDAMNoteFilter *)filter
-                       withTrash:(BOOL)withTrash
-                         success:(void(^)(EDAMNoteCollectionCounts *counts))success
-                         failure:(void(^)(NSError *error))failure
+                  includingTrash:(BOOL)includingTrash
+                      completion:(void(^)(EDAMNoteCollectionCounts *_Nullable counts, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
-        return [self.client findNoteCounts:self.authenticationToken filter:filter withTrash:withTrash];
-    } success:success failure:failure];
+    [self invokeAsyncObjectBlock:^id {
+        return [self.client findNoteCounts:self.authenticationToken filter:filter withTrash:includingTrash];
+    } completion:completion];
 }
 
 - (void)fetchNoteWithGuid:(EDAMGuid)guid
          includingContent:(BOOL)includingContent
           resourceOptions:(ENResourceFetchOption)resourceOptions
-                  success:(void(^)(EDAMNote *note))success
-                  failure:(void(^)(NSError *error))failure
+               completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNote:self.authenticationToken
                                guid:guid
                         withContent:includingContent
                   withResourcesData:EN_FLAG_ISSET(resourceOptions, ENResourceFetchOptionIncludeData)
            withResourcesRecognition:EN_FLAG_ISSET(resourceOptions, ENResourceFetchOptionIncludeRecognitionData)
          withResourcesAlternateData:EN_FLAG_ISSET(resourceOptions, ENResourceFetchOptionIncludeAlternateData)];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchNoteApplicationDataWithGuid:(EDAMGuid)guid
-                                 success:(void(^)(EDAMLazyMap *map))success
-                                 failure:(void(^)(NSError *error))failure
+                              completion:(void(^)(EDAMLazyMap *_Nullable map, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteApplicationData:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
                                           key:(NSString *)key
-                                      success:(void(^)(NSString *entry))success
-                                      failure:(void(^)(NSError *error))failure
+                                   completion:(void(^)(NSString *_Nullable entry, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteApplicationDataEntry:self.authenticationToken guid:guid key:key];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)setNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
                                         key:(NSString *)key
                                       value:(NSString *)value
-                                    success:(void(^)(int32_t usn))success
-                                    failure:(void(^)(NSError *error))failure
+                                 completion:(void(^)(int32_t usn, NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client setNoteApplicationDataEntry:self.authenticationToken guid:guid key:key value:value];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)unsetNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
                                           key:(NSString *) key
-                                      success:(void(^)(int32_t usn))success
-                                      failure:(void(^)(NSError *error))failure
+                                   completion:(void(^)(int32_t usn, NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client unsetNoteApplicationDataEntry:self.authenticationToken guid:guid key:key];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchNoteContentWithGuid:(EDAMGuid)guid
-                         success:(void(^)(NSString *content))success
-                         failure:(void(^)(NSError *error))failure
+                      completion:(void(^)(NSString *_Nullable content, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteContent:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchSearchTextForNoteWithGuid:(EDAMGuid)guid
                               noteOnly:(BOOL)noteOnly
                    tokenizeForIndexing:(BOOL)tokenizeForIndexing
-                               success:(void(^)(NSString *text))success
-                               failure:(void(^)(NSError *error))failure
+                            completion:(void(^)(NSString *_Nullable text, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteSearchText:self.authenticationToken guid:guid noteOnly:noteOnly tokenizeForIndexing:tokenizeForIndexing];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchSearchTextForResourceWithGuid:(EDAMGuid)guid
-                                   success:(void(^)(NSString *text))success
-                                   failure:(void(^)(NSError *error))failure
+                                completion:(void(^)(NSString *_Nullable text, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceSearchText:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchTagNamesForNoteWithGuid:(EDAMGuid)guid
-                             success:(void(^)(NSArray<NSString *> *names))success
-                             failure:(void(^)(NSError *error))failure
+                          completion:(void(^)(NSArray<NSString *> *_Nullable names, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteTagNames:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)createNote:(EDAMNote *)note
-           success:(void(^)(EDAMNote *note))success
-           failure:(void(^)(NSError *error))failure
+        completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client createNote:self.authenticationToken note:note];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateNote:(EDAMNote *)note
-           success:(void(^)(EDAMNote *note))success
-           failure:(void(^)(NSError *error))failure
+        completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client updateNote:self.authenticationToken note:note];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)deleteNoteWithGuid:(EDAMGuid)guid
-                   success:(void(^)(int32_t usn))success
-                   failure:(void(^)(NSError *error))failure
+                completion:(void(^)(int32_t usn, NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client deleteNote:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeNoteWithGuid:(EDAMGuid)guid
-                    success:(void(^)(int32_t usn))success
-                    failure:(void(^)(NSError *error))failure
+                 completion:(void(^)(int32_t usn, NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeNote:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeNotesWithGuids:(NSArray<EDAMGuid> *)guids
-                      success:(void(^)(int32_t usn))success
-                      failure:(void(^)(NSError *error))failure
+                   completion:(void(^)(int32_t usn, NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeNotes:self.authenticationToken noteGuids:guids];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)expungeInactiveNoteWithSuccess:(void(^)(int32_t usn))success
-                               failure:(void(^)(NSError *error))failure
+- (void)expungeInactiveNoteWithCompletion:(void(^)(int32_t usn, NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeInactiveNotes:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)copyNoteWithGuid:(EDAMGuid)guid
       toNotebookWithGuid:(EDAMGuid)notebookGuid
-                 success:(void(^)(EDAMNote *note))success
-                 failure:(void(^)(NSError *error))failure
+              completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client copyNote:self.authenticationToken noteGuid:guid toNotebookGuid:notebookGuid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)listNoteVersionsWithGuid:(EDAMGuid)guid
-                         success:(void(^)(NSArray<EDAMNoteVersionId *> *versions))success
-                         failure:(void(^)(NSError *error))failure
+                      completion:(void(^)(NSArray<EDAMNoteVersionId *> *_Nullable versions, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client listNoteVersions:self.authenticationToken noteGuid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchNoteVersionWithGuid:(EDAMGuid)guid
                updateSequenceNum:(int32_t)updateSequenceNum
                  resourceOptions:(ENResourceFetchOption)resourceOptions
-                         success:(void(^)(EDAMNote *note))success
-                         failure:(void(^)(NSError *error))failure
+                      completion:(void(^)(EDAMNote *_Nullable note, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteVersion:self.authenticationToken
                                   noteGuid:guid
                          updateSequenceNum:updateSequenceNum
                          withResourcesData:EN_FLAG_ISSET(resourceOptions, ENResourceFetchOptionIncludeData)
                   withResourcesRecognition:EN_FLAG_ISSET(resourceOptions, ENResourceFetchOptionIncludeRecognitionData)
                 withResourcesAlternateData:EN_FLAG_ISSET(resourceOptions, ENResourceFetchOptionIncludeAlternateData)];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 #pragma mark - NoteStore resource methods
 
 - (void)fetchResourceWithGuid:(EDAMGuid)guid
                       options:(ENResourceFetchOption)options
-                      success:(void(^)(EDAMResource *resource))success
-                      failure:(void(^)(NSError *error))failure
+                   completion:(void(^)(EDAMResource *_Nullable resource, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResource:self.authenticationToken
                                    guid:guid
                                withData:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeData)
                         withRecognition:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeRecognitionData)
                          withAttributes:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeAttributes)
                       withAlternateData:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeAlternateData)];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchResourceApplicationDataWithGuid:(EDAMGuid)guid
-                                     success:(void(^)(EDAMLazyMap *map))success
-                                     failure:(void(^)(NSError *error))failure
+                                  completion:(void(^)(EDAMLazyMap *_Nullable map, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceApplicationData:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
                                               key:(NSString *)key
-                                          success:(void(^)(NSString *entry))success
-                                          failure:(void(^)(NSError *error))failure
+                                       completion:(void(^)(NSString *_Nullable entry, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceApplicationDataEntry:self.authenticationToken guid:guid key:key];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)setResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
                                             key:(NSString *)key
                                           value:(NSString *)value
-                                        success:(void(^)(int32_t usn))success
-                                        failure:(void(^)(NSError *error))failure
+                                     completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client setResourceApplicationDataEntry:self.authenticationToken guid:guid key:key value:value];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)unsetResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
                                               key:(NSString *)key
-                                          success:(void(^)(int32_t usn))success
-                                          failure:(void(^)(NSError *error))failure
+                                       completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client unsetResourceApplicationDataEntry:self.authenticationToken guid:guid key:key];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateResource:(EDAMResource *)resource
-               success:(void(^)(int32_t usn))success
-               failure:(void(^)(NSError *error))failure
+            completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client updateResource:self.authenticationToken resource:resource];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchResourceDataWithGuid:(EDAMGuid)guid
-                          success:(void(^)(NSData *data))success
-                          failure:(void(^)(NSError *error))failure
+                       completion:(void(^)(NSData *_Nullable data, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceData:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchResourceByHashWithGuid:(EDAMGuid)guid
                         contentHash:(NSData *)contentHash
                             options:(ENResourceFetchOption)options
-                            success:(void(^)(EDAMResource *resource))success
-                            failure:(void(^)(NSError *error))failure
+                         completion:(void(^)(EDAMResource *_Nullable resource, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceByHash:self.authenticationToken
                                      noteGuid:guid
                                   contentHash:contentHash
                                      withData:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeData)
                               withRecognition:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeRecognitionData)
                             withAlternateData:EN_FLAG_ISSET(options, ENResourceFetchOptionIncludeAlternateData)];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchRecognitionDataForResourceWithGuid:(EDAMGuid)guid
-                                        success:(void(^)(NSData *data))success
-                                        failure:(void(^)(NSError *error))failure
+                                     completion:(void(^)(NSData *_Nullable data, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceRecognition:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchAlternateDataForResourceWithGuid:(EDAMGuid)guid
-                                      success:(void(^)(NSData *data))success
-                                      failure:(void(^)(NSError *error))failure
+                                   completion:(void(^)(NSData *_Nullable data, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceAlternateData:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchAttributesForResourceWithGuid:(EDAMGuid)guid
-                                   success:(void(^)(EDAMResourceAttributes *attributes))success
-                                   failure:(void(^)(NSError *error))failure
+                                completion:(void(^)(EDAMResourceAttributes *_Nullable attributes, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getResourceAttributes:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 #pragma mark - NoteStore shared notebook methods
 
 - (void)fetchPublicNotebookWithUserID:(EDAMUserID)userId
                             publicURI:(NSString *)publicURI
-                              success:(void(^)(EDAMNotebook *notebook))success
-                              failure:(void(^)(NSError *error))failure
+                           completion:(void(^)(EDAMNotebook *_Nullable notebook, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getPublicNotebook:userId publicUri:publicURI];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)createSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
-                     success:(void(^)(EDAMSharedNotebook *sharedNotebook))success
-                     failure:(void(^)(NSError *error))failure
+                  completion:(void(^)(EDAMSharedNotebook *_Nullable sharedNotebook, NSError *_Nullable error))completion
 
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client createSharedNotebook:self.authenticationToken sharedNotebook:sharedNotebook];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)sendMessageToMembersOfSharedNotebookWithGuid:(EDAMGuid)guid
                                          messageText:(NSString *)messageText
                                           recipients:(NSArray<NSString *> *)recipients
-                                             success:(void(^)(int32_t numMessagesSent))success
-                                             failure:(void(^)(NSError *error))failure
+                                          completion:(void(^)(int32_t numMessagesSent , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client sendMessageToSharedNotebookMembers:self.authenticationToken notebookGuid:guid messageText:messageText recipients:recipients];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)listSharedNotebooksWithSuccess:(void(^)(NSArray<EDAMSharedNotebook *> *sharedNotebooks))success
-                               failure:(void(^)(NSError *error))failure
+- (void)listSharedNotebooksWithCompletion:(void(^)(NSArray<EDAMSharedNotebook *> *_Nullable sharedNotebooks, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client listSharedNotebooks:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeSharedNotebooksWithIds:(NSArray<NSNumber *> *)sharedNotebookIds
-                              success:(void(^)(int32_t usn))success
-                              failure:(void(^)(NSError *error))failure
+                           completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeSharedNotebooks:self.authenticationToken sharedNotebookIds:sharedNotebookIds];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)createLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
-                     success:(void(^)(EDAMLinkedNotebook *linkedNotebook))success
-                     failure:(void(^)(NSError *error))failure
+                  completion:(void(^)(EDAMLinkedNotebook *_Nullable linkedNotebook, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client createLinkedNotebook:self.authenticationToken linkedNotebook:linkedNotebook];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
-                     success:(void(^)(int32_t usn))success
-                     failure:(void(^)(NSError *error))failure
+                  completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client updateLinkedNotebook:self.authenticationToken linkedNotebook:linkedNotebook];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)listLinkedNotebooksWithSuccess:(void(^)(NSArray<EDAMLinkedNotebook *> *linkedNotebooks))success
-                               failure:(void(^)(NSError *error))failure
+- (void)listLinkedNotebooksWithCompletion:(void(^)(NSArray<EDAMLinkedNotebook *> *_Nullable linkedNotebooks, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client listLinkedNotebooks:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)expungeLinkedNotebookWithGuid:(EDAMGuid)guid
-                              success:(void(^)(int32_t usn))success
-                              failure:(void(^)(NSError *error))failure
+                           completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client expungeLinkedNotebook:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)authenticateToSharedNotebook:(NSString *)shareKeyOrGlobalId
-                             success:(void(^)(EDAMAuthenticationResult *result))success
-                             failure:(void(^)(NSError *error))failure
+                          completion:(void(^)(EDAMAuthenticationResult *_Nullable result, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client authenticateToSharedNotebook:shareKeyOrGlobalId authenticationToken:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)fetchSharedNotebookByAuthWithSuccess:(void(^)(EDAMSharedNotebook *sharedNotebook))success
-                                     failure:(void(^)(NSError *error))failure
-
+- (void)fetchSharedNotebookByAuthWithCompletion:(void(^)(EDAMSharedNotebook *_Nullable sharedNotebook, NSError *_Nullable error))completion;
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getSharedNotebookByAuth:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)emailNoteWithParameters:(EDAMNoteEmailParameters *)parameters
-                        success:(void(^)())success
-                        failure:(void(^)(NSError *error))failure
+                     completion:(void(^)(NSError *error))completion
 {
-    [self invokeAsyncVoidBlock:^ {
+    [self invokeAsyncBlock:^ {
         [self.client emailNote:self.authenticationToken parameters:parameters];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)shareNoteWithGuid:(EDAMGuid)guid
-                  success:(void(^)(NSString *noteKey))success
-                  failure:(void(^)(NSError *error))failure
+               completion:(void(^)(NSString *_Nullable noteKey, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client shareNote:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)stopSharingNoteWithGuid:(EDAMGuid)guid
-                        success:(void(^)())success
-                        failure:(void(^)(NSError *error))failure
+                     completion:(void(^)(NSError *error))completion
 {
-    [self invokeAsyncVoidBlock:^ {
+    [self invokeAsyncBlock:^ {
         [self.client stopSharingNote:self.authenticationToken guid:guid];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)authenticateToSharedNoteWithGuid:(NSString *)guid
                                  noteKey:(NSString *)noteKey
-                     authenticationToken:(NSString*)authenticationToken
-                                 success:(void(^)(EDAMAuthenticationResult *result))success
-                                 failure:(void(^)(NSError *error))failure
+                     authenticationToken:(nullable NSString*)authenticationToken
+                              completion:(void(^)(EDAMAuthenticationResult *_Nullable result, NSError *_Nullable error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client authenticateToSharedNote:guid noteKey:noteKey authenticationToken:authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)updateSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
-                     success:(void(^)(int32_t usn))success
-                     failure:(void(^)(NSError *error))failure
+                  completion:(void(^)(int32_t usn , NSError *_Nullable error))completion
 {
     [self invokeAsyncInt32Block:^int32_t {
         return [self.client updateSharedNotebook:self.authenticationToken sharedNotebook:sharedNotebook];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)setRecipientSettings:(EDAMSharedNotebookRecipientSettings *) recipientSettings
      forSharedNotebookWithID:(int64_t)sharedNotebookId
-                     success:(void(^)(int32_t usn))success
-                     failure:(void(^)(NSError *error))failure {
+                  completion:(void(^)(int32_t usn , NSError *_Nullable error))completion {
     [self invokeAsyncInt32Block:^int32_t{
         return [self.client setSharedNotebookRecipientSettings:self.authenticationToken sharedNotebookId:sharedNotebookId recipientSettings:recipientSettings];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void) cancelFirstOperation {
     [[self client] cancel];
 }
+
+
 
 #pragma mark - Protected routines
 
@@ -906,35 +835,41 @@
     if (maxResults > 0) {
         maxNotesThisCall = (int32_t)MIN(maxResults - results.count, (NSUInteger)maxNotesThisCall);
     }
-    
+
     [self findNotesMetadataWithFilter:filter
                                offset:offset
                              maxNotes:maxNotesThisCall
                            resultSpec:resultSpec
-                              success:^(EDAMNotesMetadataList *metadata) {
-                                  // Add these results.
-                                  [results addObjectsFromArray:metadata.notes];
-                                  // Did we reach the total? (Use this formulation instead of checking against the results array length
-                                  // because in theory the note count total could change between calls.
-                                  int32_t nextIndex = [metadata.startIndex intValue] + (int32_t)metadata.notes.count;
-                                  int32_t remainingCount = [metadata.totalNotes intValue] - nextIndex;
-                                  // Go for another round if there are more to get.
-                                  if (remainingCount > 0) {
-                                      [self findNotesMetadataInternalWithFilter:filter
-                                                                         offset:nextIndex
-                                                                     resultSpec:resultSpec
-                                                                     maxResults:maxResults
-                                                                        results:results
-                                                                        success:success
-                                                                        failure:failure];
-                                  } else {
-                                      // Done.
-                                      success(results);
-                                  }
-                              } failure:^(NSError *error) {
-                                  failure(error);
-                              }];
+                           completion:^(EDAMNotesMetadataList * _Nullable metadata, NSError * _Nullable error) {
+                               if (error) {
+                                   failure(error);
+                                   return;
+                               }
+                               // Add these results.
+                               [results addObjectsFromArray:metadata.notes];
+                               // Did we reach the total? (Use this formulation instead of checking against the results array length
+                               // because in theory the note count total could change between calls.
+                               int32_t nextIndex = [metadata.startIndex intValue] + (int32_t)metadata.notes.count;
+                               int32_t remainingCount = [metadata.totalNotes intValue] - nextIndex;
+                               // Go for another round if there are more to get.
+                               if (remainingCount > 0) {
+                                   [self findNotesMetadataInternalWithFilter:filter
+                                                                      offset:nextIndex
+                                                                  resultSpec:resultSpec
+                                                                  maxResults:maxResults
+                                                                     results:results
+                                                                     success:success
+                                                                     failure:failure];
+                               } else {
+                                   // Done.
+                                   success(results);
+                               }
+                           }];
 }
+
+
+
+
 
 
 
@@ -943,7 +878,9 @@
 - (void)getSyncStateWithSuccess:(void(^)(EDAMSyncState *syncState))success
                         failure:(void(^)(NSError *error))failure
 {
-  [self fetchSyncStateWithSuccess:success failure:failure];
+    [self fetchSyncStateWithCompletion:^(EDAMSyncState * _Nullable syncState, NSError * _Nullable error) {
+        (error != nil) ? success(syncState) : failure(error);
+    }];
 }
 
 - (void)getSyncChunkAfterUSN:(int32_t)afterUSN
@@ -952,7 +889,9 @@
                      success:(void(^)(EDAMSyncChunk *syncChunk))success
                      failure:(void(^)(NSError *error))failure
 {
-  [self fetchSyncChunkAfterUSN:afterUSN maxEntries:maxEntries fullSyncOnly:fullSyncOnly success:success failure:failure];
+    [self fetchSyncChunkAfterUSN:afterUSN maxEntries:maxEntries fullSyncOnly:fullSyncOnly completion:^(EDAMSyncChunk * _Nullable syncChunk, NSError * _Nullable error) {
+        (error != nil) ? success(syncChunk) : failure(error);
+    }];
 }
 
 - (void)getFilteredSyncChunkAfterUSN:(int32_t)afterUSN
@@ -961,186 +900,242 @@
                              success:(void(^)(EDAMSyncChunk *syncChunk))success
                              failure:(void(^)(NSError *error))failure
 {
-  [self fetchFilteredSyncChunkAfterUSN:afterUSN maxEntries:maxEntries filter:filter success:success failure:failure];
+    [self fetchFilteredSyncChunkAfterUSN:afterUSN maxEntries:maxEntries filter:filter completion:^(EDAMSyncChunk * _Nullable syncChunk, NSError * _Nullable error) {
+        (error != nil) ? success(syncChunk) : failure(error);
+    }];
 }
 
 - (void)getLinkedNotebookSyncState:(EDAMLinkedNotebook *)linkedNotebook
                            success:(void(^)(EDAMSyncState *syncState))success
                            failure:(void(^)(NSError *error))failure
 {
-  [self fetchSyncStateForLinkedNotebook:linkedNotebook success:success failure:failure];
+    [self fetchSyncStateForLinkedNotebook:linkedNotebook completion:^(EDAMSyncState * _Nullable syncState, NSError * _Nullable error) {
+        (error != nil) ? success(syncState) : failure(error);
+    }];
 }
 
 - (void)getLinkedNotebookSyncChunk:(EDAMLinkedNotebook *)linkedNotebook
                           afterUSN:(int32_t)afterUSN
-                        maxEntries:(int32_t) maxEntries
+                        maxEntries:(int32_t)maxEntries
                       fullSyncOnly:(BOOL)fullSyncOnly
                            success:(void(^)(EDAMSyncChunk *syncChunk))success
                            failure:(void(^)(NSError *error))failure
 {
-  [self fetchSyncChunkForLinkedNotebook:linkedNotebook afterUSN:afterUSN maxEntries:maxEntries fullSyncOnly:fullSyncOnly success:success failure:failure];
+    [self fetchSyncChunkForLinkedNotebook:linkedNotebook afterUSN:afterUSN maxEntries:maxEntries fullSyncOnly:fullSyncOnly completion:^(EDAMSyncChunk * _Nullable syncChunk, NSError * _Nullable error) {
+        (error != nil) ? success(syncChunk) : failure(error);
+    }];
+}
+
+- (void)listNotebooksWithSuccess:(void(^)(NSArray<EDAMNotebook *> *notebooks))success
+                         failure:(void(^)(NSError *error))failure
+{
+    [self listNotebooksWithCompletion:^(NSArray<EDAMNotebook *> * _Nullable notebooks, NSError * _Nullable error) {
+        (error != nil) ? success(notebooks) : failure(error);
+    }];
 }
 
 - (void)getNotebookWithGuid:(EDAMGuid)guid
                     success:(void(^)(EDAMNotebook *notebook))success
                     failure:(void(^)(NSError *error))failure
 {
-  [self fetchNotebookWithGuid:guid success:success failure:failure];
+    [self fetchNotebookWithGuid:guid completion:^(EDAMNotebook * _Nullable notebook, NSError * _Nullable error) {
+        (error != nil) ? success(notebook) : failure(error);
+    }];
 }
 
 - (void)getDefaultNotebookWithSuccess:(void(^)(EDAMNotebook *notebook))success
                               failure:(void(^)(NSError *error))failure
 {
-  [self fetchDefaultNotebookWithSuccess:success failure:failure];
+    [self fetchDefaultNotebookWithCompletion:^(EDAMNotebook * _Nullable notebook, NSError * _Nullable error) {
+        (error != nil) ? success(notebook) : failure(error);
+    }];
 }
 
-- (void)getTagWithGuid:(EDAMGuid)guid
-               success:(void(^)(EDAMTag *tag))success
+- (void)createNotebook:(EDAMNotebook *)notebook
+               success:(void(^)(EDAMNotebook *notebook))success
                failure:(void(^)(NSError *error))failure
 {
-  [self fetchTagWithGuid:guid success:success failure:failure];
+    [self createNotebook:notebook completion:^(EDAMNotebook * _Nullable createdNotebook, NSError * _Nullable error) {
+        (error != nil) ? success(createdNotebook) : failure(error);
+    }];
 }
 
-- (void)getSearchWithGuid:(EDAMGuid)guid
-                  success:(void(^)(EDAMSavedSearch *search))success
-                  failure:(void(^)(NSError *error))failure
-
+- (void)updateNotebook:(EDAMNotebook *)notebook
+               success:(void(^)(int32_t usn))success
+               failure:(void(^)(NSError *error))failure
 {
-  [self fetchSearchWithGuid:guid success:success failure:failure];
+    [self updateNotebook:notebook completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
 }
 
-- (void)getNoteApplicationDataWithGuid:(EDAMGuid)guid
-                               success:(void(^)(EDAMLazyMap *map))success
-                               failure:(void(^)(NSError *error))failure
-{
-  [self fetchNoteApplicationDataWithGuid:guid success:success failure:failure];
-}
-
-- (void)getNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
-                                        key:(NSString *)key
-                                    success:(void(^)(NSString *entry))success
-                                    failure:(void(^)(NSError *error))failure
-{
-  [self fetchNoteApplicationDataEntryWithGuid:guid key:key success:success failure:failure];
-}
-
-- (void)getNoteContentWithGuid:(EDAMGuid)guid
-                       success:(void(^)(NSString *content))success
-                       failure:(void(^)(NSError *error))failure
-{
-  [self fetchNoteContentWithGuid:guid success:success failure:failure];
-}
-
-- (void)getNoteSearchTextWithGuid:(EDAMGuid)guid
-                         noteOnly:(BOOL)noteOnly
-              tokenizeForIndexing:(BOOL)tokenizeForIndexing
-                          success:(void(^)(NSString *text))success
-                          failure:(void(^)(NSError *error))failure
-{
-  [self fetchSearchTextForNoteWithGuid:guid noteOnly:noteOnly tokenizeForIndexing:tokenizeForIndexing success:success failure:failure];
-}
-
-- (void)getResourceSearchTextWithGuid:(EDAMGuid)guid
-                              success:(void(^)(NSString *text))success
-                              failure:(void(^)(NSError *error))failure
-{
-    [self fetchSearchTextForResourceWithGuid:guid success:success failure:failure];
-}
-
-- (void)getNoteTagNamesWithGuid:(EDAMGuid)guid
-                        success:(void(^)(NSArray<NSString *> *names))success
+- (void)expungeNotebookWithGuid:(EDAMGuid)guid
+                        success:(void(^)(int32_t usn))success
                         failure:(void(^)(NSError *error))failure
 {
-    [self fetchTagNamesForNoteWithGuid:guid success:success failure:failure];
+    [self expungeNotebookWithGuid:guid completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
 }
 
-- (void)getResourceApplicationDataWithGuid:(EDAMGuid)guid
-                                   success:(void(^)(EDAMLazyMap *map))success
-                                   failure:(void(^)(NSError *error))failure
+- (void)listTagsWithSuccess:(void(^)(NSArray<EDAMTag *> *tags))success
+                    failure:(void(^)(NSError *error))failure
 {
-    [self fetchResourceApplicationDataWithGuid:guid success:success failure:failure];
-}
-
-- (void)getResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
-                                            key:(NSString *)key
-                                        success:(void(^)(NSString *entry))success
-                                        failure:(void(^)(NSError *error))failure
-{
-    [self fetchResourceApplicationDataEntryWithGuid:guid key:key success:success failure:failure];
-}
-
-- (void)getResourceDataWithGuid:(EDAMGuid)guid
-                        success:(void(^)(NSData *data))success
-                        failure:(void(^)(NSError *error))failure
-{
-    [self fetchResourceDataWithGuid:guid success:success failure:failure];
-}
-
-- (void)getResourceRecognitionWithGuid:(EDAMGuid)guid
-                               success:(void(^)(NSData *data))success
-                               failure:(void(^)(NSError *error))failure
-{
-    [self fetchRecognitionDataForResourceWithGuid:guid success:success failure:failure];
-}
-
-- (void)getResourceAlternateDataWithGuid:(EDAMGuid)guid
-                                 success:(void(^)(NSData *data))success
-                                 failure:(void(^)(NSError *error))failure
-{
-    [self fetchAlternateDataForResourceWithGuid:guid success:success failure:failure];
-}
-
-- (void)getResourceAttributesWithGuid:(EDAMGuid)guid
-                              success:(void(^)(EDAMResourceAttributes *attributes))success
-                              failure:(void(^)(NSError *error))failure
-{
-    [self fetchAttributesForResourceWithGuid:guid success:success failure:failure];
-}
-
-- (void)getPublicNotebookWithUserID:(EDAMUserID)userId
-                          publicUri:(NSString *)publicURI
-                            success:(void(^)(EDAMNotebook *notebook))success
-                            failure:(void(^)(NSError *error))failure
-{
-    [self fetchPublicNotebookWithUserID:userId publicURI:publicURI success:success failure:failure];
-}
-
-- (void)getSharedNotebookByAuthWithSuccess:(void(^)(EDAMSharedNotebook *sharedNotebook))success
-                                   failure:(void(^)(NSError *error))failure
-
-{
-    [self fetchSharedNotebookByAuthWithSuccess:success failure:failure];
+    [self listTagsWithCompletion:^(NSArray<EDAMTag *> * _Nullable tags, NSError * _Nullable error) {
+        (error != nil) ? success(tags) : failure(error);
+    }];
 }
 
 - (void)listTagsByNotebookWithGuid:(EDAMGuid)guid
                            success:(void(^)(NSArray<EDAMTag *> *tags))success
                            failure:(void(^)(NSError *error))failure
 {
-  [self listTagsInNotebookWithGuid:guid success:success failure:failure];
-};
+    [self listTagsInNotebookWithGuid:guid completion:^(NSArray<EDAMTag *> *_Nullable tags, NSError * _Nullable error) {
+        (error != nil) ? success(tags) : failure(error);
+    }];
+}
 
-- (void)copyNoteWithGuid:(EDAMGuid)guid
-          toNoteBookGuid:(EDAMGuid)toNotebookGuid
-                 success:(void(^)(EDAMNote *note))success
+- (void)getTagWithGuid:(EDAMGuid)guid
+               success:(void(^)(EDAMTag *tag))success
+               failure:(void(^)(NSError *error))failure
+{
+    [self fetchTagWithGuid:guid completion:^(EDAMTag * _Nullable tag, NSError * _Nullable error) {
+        (error != nil) ? success(tag) : failure(error);
+    }];
+}
+
+- (void)createTag:(EDAMTag *)tag
+          success:(void(^)(EDAMTag *tag))success
+          failure:(void(^)(NSError *error))failure
+{
+    [self createTag:tag completion:^(EDAMTag * _Nullable createdTag, NSError * _Nullable error) {
+        (error != nil) ? success(createdTag) : failure(error);
+    }];
+}
+
+- (void)updateTag:(EDAMTag *)tag
+          success:(void(^)(int32_t usn))success
+          failure:(void(^)(NSError *error))failure
+{
+    [self updateTag:tag completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)untagAllWithGuid:(EDAMGuid)guid
+                 success:(void(^)())success
                  failure:(void(^)(NSError *error))failure
 {
-  [self copyNoteWithGuid:guid toNotebookWithGuid:toNotebookGuid success:success failure:failure];
+    [self untagAllWithGuid:guid completion:^(NSError * _Nonnull error) {
+        (error != nil) ? success() : failure(error);
+    }];
 }
 
-- (void)sendMessageToSharedNotebookMembersWithGuid:(EDAMGuid)guid
-                                       messageText:(NSString *)messageText
-                                        recipients:(NSArray<NSString *> *)recipients
-                                           success:(void(^)(int32_t numMessagesSent))success
-                                           failure:(void(^)(NSError *error))failure
+- (void)expungeTagWithGuid:(EDAMGuid)guid
+                   success:(void(^)(int32_t usn))success
+                   failure:(void(^)(NSError *error))failure
 {
-  [self sendMessageToMembersOfSharedNotebookWithGuid:guid messageText:messageText recipients:recipients success:success failure:failure];
+    [self expungeTagWithGuid:guid completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
 }
 
-- (void) setSharedNotebookRecipientSettingsWithSharedNotebookId: (int64_t) sharedNotebookId
-                                              recipientSettings: (EDAMSharedNotebookRecipientSettings *) recipientSettings
-                                                        success:(void(^)(int32_t usn))success
-                                                        failure:(void(^)(NSError *error))failure {
-  [self setRecipientSettings:recipientSettings forSharedNotebookWithID:sharedNotebookId success:success failure:failure];
+- (void)listSearchesWithSuccess:(void(^)(NSArray<EDAMSavedSearch *> *searches))success
+                        failure:(void(^)(NSError *error))failure
+{
+    [self listSearchesWithCompletion:^(NSArray<EDAMSavedSearch *> * _Nullable searches, NSError * _Nullable error) {
+        (error != nil) ? success(searches) : failure(error);
+    }];
+}
+
+- (void)getSearchWithGuid:(EDAMGuid)guid
+                  success:(void(^)(EDAMSavedSearch *search))success
+                  failure:(void(^)(NSError *error))failure
+{
+    [self fetchSearchWithGuid:guid completion:^(EDAMSavedSearch * _Nullable search, NSError * _Nullable error) {
+        (error != nil) ? success(search) : failure(error);
+    }];
+}
+
+- (void)createSearch:(EDAMSavedSearch *)search
+             success:(void(^)(EDAMSavedSearch *search))success
+             failure:(void(^)(NSError *error))failure
+{
+    [self createSearch:search completion:^(EDAMSavedSearch * _Nullable createdSearch, NSError * _Nullable error) {
+        (error != nil) ? success(createdSearch) : failure(error);
+    }];
+}
+
+- (void)updateSearch:(EDAMSavedSearch *)search
+             success:(void(^)(int32_t usn))success
+             failure:(void(^)(NSError *error))failure
+{
+    [self updateSearch:search completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)expungeSearchWithGuid:(EDAMGuid)guid
+                      success:(void(^)(int32_t usn))success
+                      failure:(void(^)(NSError *error))failure
+{
+    [self expungeSearchWithGuid:guid completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)findRelatedWithQuery:(EDAMRelatedQuery *)query
+                  resultSpec:(EDAMRelatedResultSpec *)resultSpec
+                     success:(void(^)(EDAMRelatedResult *result))success
+                     failure:(void(^)(NSError *error))failure
+{
+    [self findRelatedWithQuery:query resultSpec:resultSpec completion:^(EDAMRelatedResult * _Nullable result, NSError * _Nullable error) {
+        (error != nil) ? success(result) : failure(error);
+    }];
+}
+
+- (void)findNotesWithFilter:(EDAMNoteFilter *)filter
+                     offset:(int32_t)offset
+                   maxNotes:(int32_t)maxNotes
+                    success:(void(^)(EDAMNoteList *list))success
+                    failure:(void(^)(NSError *error))failure
+{
+    [self findNotesWithFilter:filter offset:offset maxNotes:maxNotes completion:^(EDAMNoteList * _Nullable list, NSError * _Nullable error) {
+        (error != nil) ? success(list) : failure(error);
+    }];
+}
+
+- (void)findNoteOffsetWithFilter:(EDAMNoteFilter *)filter
+                            guid:(EDAMGuid)guid
+                         success:(void(^)(int32_t offset))success
+                         failure:(void(^)(NSError *error))failure
+{
+    [self findNoteOffsetWithFilter:filter guid:guid completion:^(int32_t offset, NSError * _Nullable error) {
+        (error != nil) ? success(offset) : failure(error);
+    }];
+}
+
+- (void)findNotesMetadataWithFilter:(EDAMNoteFilter *)filter
+                             offset:(int32_t)offset
+                           maxNotes:(int32_t)maxNotes
+                         resultSpec:(EDAMNotesMetadataResultSpec *)resultSpec
+                            success:(void(^)(EDAMNotesMetadataList *metadata))success
+                            failure:(void(^)(NSError *error))failure
+{
+    [self findNotesMetadataWithFilter:filter offset:offset maxNotes:maxNotes resultSpec:resultSpec completion:^(EDAMNotesMetadataList * _Nullable metadata, NSError * _Nullable error) {
+        (error != nil) ? success(metadata) : failure(error);
+    }];
+}
+
+
+- (void)findNoteCountsWithFilter:(EDAMNoteFilter *)filter
+                       withTrash:(BOOL)withTrash
+                         success:(void(^)(EDAMNoteCollectionCounts *counts))success
+                         failure:(void(^)(NSError *error))failure
+{
+    [self findNoteCountsWithFilter:filter includingTrash:withTrash completion:^(EDAMNoteCollectionCounts * _Nullable counts, NSError * _Nullable error) {
+        (error != nil) ? success(counts) : failure(error);
+    }];
 }
 
 - (void)getNoteWithGuid:(EDAMGuid)guid
@@ -1161,7 +1156,159 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
     if (withResourcesAlternateData) {
         EN_FLAG_SET(options, ENResourceFetchOptionIncludeAlternateData);
     }
-    [self fetchNoteWithGuid:guid includingContent:withContent resourceOptions:options success:success failure:failure];
+    [self fetchNoteWithGuid:guid includingContent:withContent resourceOptions:options completion:^(EDAMNote * _Nullable note, NSError * _Nullable error) {
+        (error != nil) ? success(note) : failure(error);
+    }];
+}
+
+- (void)getNoteApplicationDataWithGuid:(EDAMGuid)guid
+                               success:(void(^)(EDAMLazyMap *map))success
+                               failure:(void(^)(NSError *error))failure
+{
+    [self fetchNoteApplicationDataWithGuid:guid completion:^(EDAMLazyMap * _Nullable map, NSError * _Nullable error) {
+        (error != nil) ? success(map) : failure(error);
+    }];
+}
+
+- (void)getNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                        key:(NSString *)key
+                                    success:(void(^)(NSString *entry))success
+                                    failure:(void(^)(NSError *error))failure
+{
+    [self fetchNoteApplicationDataEntryWithGuid:guid key:key completion:^(NSString * _Nullable entry, NSError * _Nullable error) {
+        (error != nil) ? success(entry) : failure(error);
+    }];
+}
+
+- (void)setNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                        key:(NSString *)key
+                                      value:(NSString *)value
+                                    success:(void(^)(int32_t usn))success
+                                    failure:(void(^)(NSError *error))failure
+{
+    [self setNoteApplicationDataEntryWithGuid:guid key:key value:value completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)unsetNoteApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                          key:(NSString *) key
+                                      success:(void(^)(int32_t usn))success
+                                      failure:(void(^)(NSError *error))failure
+{
+    [self unsetNoteApplicationDataEntryWithGuid:guid key:key completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)getNoteContentWithGuid:(EDAMGuid)guid
+                       success:(void(^)(NSString *content))success
+                       failure:(void(^)(NSError *error))failure
+{
+    [self fetchNoteContentWithGuid:guid completion:^(NSString * _Nullable content, NSError * _Nullable error) {
+        (error != nil) ? success(content) : failure(error);
+    }];
+}
+
+- (void)getNoteSearchTextWithGuid:(EDAMGuid)guid
+                         noteOnly:(BOOL)noteOnly
+              tokenizeForIndexing:(BOOL)tokenizeForIndexing
+                          success:(void(^)(NSString *text))success
+                          failure:(void(^)(NSError *error))failure
+{
+    [self fetchSearchTextForNoteWithGuid:guid noteOnly:noteOnly tokenizeForIndexing:tokenizeForIndexing completion:^(NSString * _Nullable text, NSError * _Nullable error) {
+        (error != nil) ? success(text) : failure(error);
+    }];
+}
+
+- (void)getResourceSearchTextWithGuid:(EDAMGuid)guid
+                              success:(void(^)(NSString *text))success
+                              failure:(void(^)(NSError *error))failure
+{
+    [self fetchSearchTextForResourceWithGuid:guid completion:^(NSString * _Nullable text, NSError * _Nullable error) {
+        (error != nil) ? success(text) : failure(error);
+    }];
+}
+
+- (void)getNoteTagNamesWithGuid:(EDAMGuid)guid
+                        success:(void(^)(NSArray<NSString *> *names))success
+                        failure:(void(^)(NSError *error))failure
+{
+    [self fetchTagNamesForNoteWithGuid:guid completion:^(NSArray<NSString *> * _Nullable names, NSError * _Nullable error) {
+        (error != nil) ? success(names) : failure(error);
+    }];
+}
+
+- (void)createNote:(EDAMNote *)note
+           success:(void(^)(EDAMNote *note))success
+           failure:(void(^)(NSError *error))failure
+{
+    [self createNote:note completion:^(EDAMNote * _Nullable createdNote, NSError * _Nullable error) {
+        (error != nil) ? success(createdNote) : failure(error);
+    }];
+}
+
+- (void)updateNote:(EDAMNote *)note
+           success:(void(^)(EDAMNote *note))success
+           failure:(void(^)(NSError *error))failure
+{
+    [self updateNote:note completion:^(EDAMNote * _Nullable updatedNote, NSError * _Nullable error) {
+        (error != nil) ? success(updatedNote) : failure(error);
+    }];
+}
+
+- (void)deleteNoteWithGuid:(EDAMGuid)guid
+                   success:(void(^)(int32_t usn))success
+                   failure:(void(^)(NSError *error))failure
+{
+    [self deleteNoteWithGuid:guid completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)expungeNoteWithGuid:(EDAMGuid)guid
+                    success:(void(^)(int32_t usn))success
+                    failure:(void(^)(NSError *error))failure
+{
+    [self expungeNoteWithGuid:guid completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)expungeNotesWithGuids:(NSArray<EDAMGuid> *)guids
+                      success:(void(^)(int32_t usn))success
+                      failure:(void(^)(NSError *error))failure
+{
+    [self expungeNotesWithGuids:guids completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)expungeInactiveNoteWithSuccess:(void(^)(int32_t usn))success
+                               failure:(void(^)(NSError *error))failure
+{
+    [self expungeInactiveNoteWithCompletion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)copyNoteWithGuid:(EDAMGuid)guid
+          toNoteBookGuid:(EDAMGuid)toNotebookGuid
+                 success:(void(^)(EDAMNote *note))success
+                 failure:(void(^)(NSError *error))failure
+{
+    [self copyNoteWithGuid:guid toNotebookWithGuid:toNotebookGuid completion:^(EDAMNote * _Nullable note, NSError * _Nullable error) {
+        (error != nil) ? success(note) : failure(error);
+    }];
+}
+
+- (void)listNoteVersionsWithGuid:(EDAMGuid)guid
+                         success:(void(^)(NSArray<EDAMNoteVersionId *> *versions))success
+                         failure:(void(^)(NSError *error))failure
+{
+    [self listNoteVersionsWithGuid:guid completion:^(NSArray<EDAMNoteVersionId *> * _Nullable versions, NSError * _Nullable error) {
+        (error != nil) ? success(versions) : failure(error);
+    }];
 }
 
 - (void)getNoteVersionWithGuid:(EDAMGuid)guid
@@ -1182,8 +1329,11 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
     if (withResourcesAlternateData) {
         EN_FLAG_SET(options, ENResourceFetchOptionIncludeAlternateData);
     }
-    [self fetchNoteVersionWithGuid:guid updateSequenceNum:updateSequenceNum resourceOptions:options success:success failure:failure];
+    [self fetchNoteVersionWithGuid:guid updateSequenceNum:updateSequenceNum resourceOptions:options completion:^(EDAMNote * _Nullable note, NSError * _Nullable error) {
+        (error != nil) ? success(note) : failure(error);
+    }];
 }
+
 
 - (void)getResourceWithGuid:(EDAMGuid)guid
                    withData:(BOOL)withData
@@ -1206,7 +1356,67 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
     if (withAttributes) {
         EN_FLAG_SET(options, ENResourceFetchOptionIncludeAttributes);
     }
-    [self fetchResourceWithGuid:guid options:options success:success failure:failure];
+    [self fetchResourceWithGuid:guid options:options completion:^(EDAMResource * _Nullable resource, NSError * _Nullable error) {
+        (error != nil) ? success(resource) : failure(error);
+    }];
+}
+
+- (void)getResourceApplicationDataWithGuid:(EDAMGuid)guid
+                                   success:(void(^)(EDAMLazyMap *map))success
+                                   failure:(void(^)(NSError *error))failure
+{
+    [self fetchResourceApplicationDataWithGuid:guid completion:^(EDAMLazyMap * _Nullable map, NSError * _Nullable error) {
+        (error != nil) ? success(map) : failure(error);
+    }];
+}
+
+- (void)getResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                            key:(NSString *)key
+                                        success:(void(^)(NSString *entry))success
+                                        failure:(void(^)(NSError *error))failure
+{
+    [self fetchResourceApplicationDataEntryWithGuid:guid key:key completion:^(NSString * _Nullable entry, NSError * _Nullable error) {
+        (error != nil) ? success(entry) : failure(error);
+    }];
+}
+
+- (void)setResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                            key:(NSString *)key
+                                          value:(NSString *)value
+                                        success:(void(^)(int32_t usn))success
+                                        failure:(void(^)(NSError *error))failure
+{
+    [self setResourceApplicationDataEntryWithGuid:guid key:key value:value completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)unsetResourceApplicationDataEntryWithGuid:(EDAMGuid)guid
+                                              key:(NSString *)key
+                                          success:(void(^)(int32_t usn))success
+                                          failure:(void(^)(NSError *error))failure
+{
+    [self unsetResourceApplicationDataEntryWithGuid:guid key:key completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)updateResource:(EDAMResource *)resource
+               success:(void(^)(int32_t usn))success
+               failure:(void(^)(NSError *error))failure
+{
+    [self updateResource:resource completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)getResourceDataWithGuid:(EDAMGuid)guid
+                        success:(void(^)(NSData *data))success
+                        failure:(void(^)(NSError *error))failure
+{
+    [self fetchResourceDataWithGuid:guid completion:^(NSData * _Nullable data, NSError * _Nullable error) {
+        (error != nil) ? success(data) : failure(error);
+    }];
 }
 
 - (void)getResourceByHashWithGuid:(EDAMGuid)guid
@@ -1227,7 +1437,192 @@ withResourcesAlternateData:(BOOL)withResourcesAlternateData
     if (withAlternateData) {
         EN_FLAG_SET(options, ENResourceFetchOptionIncludeAlternateData);
     }
-    [self fetchResourceByHashWithGuid:guid contentHash:contentHash options:options success:success failure:failure];
+    [self fetchResourceByHashWithGuid:guid contentHash:contentHash options:options completion:^(EDAMResource * _Nullable resource, NSError * _Nullable error) {
+        (error != nil) ? success(resource) : failure(error);
+    }];
+}
+
+- (void)getResourceRecognitionWithGuid:(EDAMGuid)guid
+                               success:(void(^)(NSData *data))success
+                               failure:(void(^)(NSError *error))failure
+{
+    [self fetchRecognitionDataForResourceWithGuid:guid completion:^(NSData * _Nullable data, NSError * _Nullable error) {
+        (error != nil) ? success(data) : failure(error);
+    }];
+}
+
+- (void)getResourceAlternateDataWithGuid:(EDAMGuid)guid
+                                 success:(void(^)(NSData *data))success
+                                 failure:(void(^)(NSError *error))failure
+{
+    [self fetchAlternateDataForResourceWithGuid:guid completion:^(NSData * _Nullable data, NSError * _Nullable error) {
+        (error != nil) ? success(data) : failure(error);
+    }];
+}
+
+- (void)getResourceAttributesWithGuid:(EDAMGuid)guid
+                              success:(void(^)(EDAMResourceAttributes *attributes))success
+                              failure:(void(^)(NSError *error))failure
+{
+    [self fetchAttributesForResourceWithGuid:guid completion:^(EDAMResourceAttributes * _Nullable attributes, NSError * _Nullable error) {
+        (error != nil) ? success(attributes) : failure(error);
+    }];
+}
+
+- (void)getPublicNotebookWithUserID:(EDAMUserID)userId
+                          publicUri:(NSString *)publicUri
+                            success:(void(^)(EDAMNotebook *notebook))success
+                            failure:(void(^)(NSError *error))failure
+{
+    [self fetchPublicNotebookWithUserID:userId publicURI:publicUri completion:^(EDAMNotebook * _Nullable notebook, NSError * _Nullable error) {
+        (error != nil) ? success(notebook) : failure(error);
+    }];
+}
+
+- (void)createSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
+                     success:(void(^)(EDAMSharedNotebook *sharedNotebook))success
+                     failure:(void(^)(NSError *error))failure
+{
+    [self createSharedNotebook:sharedNotebook completion:^(EDAMSharedNotebook * _Nullable createdSharedNotebook, NSError * _Nullable error) {
+        (error != nil) ? success(createdSharedNotebook) : failure(error);
+    }];
+}
+
+- (void)sendMessageToSharedNotebookMembersWithGuid:(EDAMGuid)guid
+                                       messageText:(NSString *)messageText
+                                        recipients:(NSArray<NSString *> *)recipients
+                                           success:(void(^)(int32_t numMessagesSent))success
+                                           failure:(void(^)(NSError *error))failure
+{
+    [self sendMessageToMembersOfSharedNotebookWithGuid:guid messageText:messageText recipients:recipients completion:^(int32_t numMessagesSent, NSError * _Nullable error) {
+        (error != nil) ? success(numMessagesSent) : failure(error);
+    }];
+}
+
+- (void)listSharedNotebooksWithSuccess:(void(^)(NSArray<EDAMSharedNotebook *> *sharedNotebooks))success
+                               failure:(void(^)(NSError *error))failure
+{
+    [self listSharedNotebooksWithCompletion:^(NSArray<EDAMSharedNotebook *> * _Nullable sharedNotebooks, NSError * _Nullable error) {
+        (error != nil) ? success(sharedNotebooks) : failure(error);
+    }];
+}
+
+- (void)expungeSharedNotebooksWithIds:(NSArray<NSNumber *> *)sharedNotebookIds
+                              success:(void(^)(int32_t usn))success
+                              failure:(void(^)(NSError *error))failure
+{
+    [self expungeSharedNotebooksWithIds:sharedNotebookIds completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)createLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
+                     success:(void(^)(EDAMLinkedNotebook *linkedNotebook))success
+                     failure:(void(^)(NSError *error))failure
+{
+    [self createLinkedNotebook:linkedNotebook completion:^(EDAMLinkedNotebook * _Nullable createdLinkedNotebook, NSError * _Nullable error) {
+        (error != nil) ? success(createdLinkedNotebook) : failure(error);
+    }];
+}
+
+- (void)updateLinkedNotebook:(EDAMLinkedNotebook *)linkedNotebook
+                     success:(void(^)(int32_t usn))success
+                     failure:(void(^)(NSError *error))failure
+{
+    [self updateLinkedNotebook:linkedNotebook completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)listLinkedNotebooksWithSuccess:(void(^)(NSArray<EDAMLinkedNotebook *> *linkedNotebooks))success
+                               failure:(void(^)(NSError *error))failure
+{
+    [self listLinkedNotebooksWithCompletion:^(NSArray<EDAMLinkedNotebook *> * _Nullable linkedNotebooks, NSError * _Nullable error) {
+        (error != nil) ? success(linkedNotebooks) : failure(error);
+    }];
+}
+
+- (void)expungeLinkedNotebookWithGuid:(EDAMGuid)guid
+                              success:(void(^)(int32_t usn))success
+                              failure:(void(^)(NSError *error))failure
+{
+    [self expungeLinkedNotebookWithGuid:guid completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void)authenticateToSharedNotebook:(NSString *)shareKeyOrGlobalId
+                             success:(void(^)(EDAMAuthenticationResult *result))success
+                             failure:(void(^)(NSError *error))failure
+{
+    [self authenticateToSharedNotebook:shareKeyOrGlobalId completion:^(EDAMAuthenticationResult * _Nullable result, NSError * _Nullable error) {
+        (error != nil) ? success(result) : failure(error);
+    }];
+}
+
+- (void)getSharedNotebookByAuthWithSuccess:(void(^)(EDAMSharedNotebook *sharedNotebook))success
+                                   failure:(void(^)(NSError *error))failure
+{
+    [self fetchSharedNotebookByAuthWithCompletion:^(EDAMSharedNotebook * _Nullable sharedNotebook, NSError * _Nullable error) {
+        (error != nil) ? success(sharedNotebook) : failure(error);
+    }];
+}
+
+- (void)emailNoteWithParameters:(EDAMNoteEmailParameters *)parameters
+                        success:(void(^)())success
+                        failure:(void(^)(NSError *error))failure
+{
+    [self emailNoteWithParameters:parameters completion:^(NSError * _Nonnull error) {
+        (error != nil) ? success() : failure(error);
+    }];
+}
+
+- (void)shareNoteWithGuid:(EDAMGuid)guid
+                  success:(void(^)(NSString *noteKey))success
+                  failure:(void(^)(NSError *error))failure
+{
+    [self shareNoteWithGuid:guid completion:^(NSString * _Nullable noteKey, NSError * _Nullable error) {
+        (error != nil) ? success(noteKey) : failure(error);
+    }];
+}
+
+- (void)stopSharingNoteWithGuid:(EDAMGuid)guid
+                        success:(void(^)())success
+                        failure:(void(^)(NSError *error))failure
+{
+    [self stopSharingNoteWithGuid:guid completion:^(NSError * _Nonnull error) {
+        (error != nil) ? success() : failure(error);
+    }];
+}
+
+- (void)authenticateToSharedNoteWithGuid:(NSString *)guid
+                                 noteKey:(NSString *)noteKey
+                     authenticationToken:(nullable NSString*)authenticationToken
+                                 success:(void(^)(EDAMAuthenticationResult *result))success
+                                 failure:(void(^)(NSError *error))failure
+{
+    [self authenticateToSharedNoteWithGuid:guid noteKey:noteKey authenticationToken:authenticationToken completion:^(EDAMAuthenticationResult * _Nullable result, NSError * _Nullable error) {
+        (error != nil) ? success(result) : failure(error);
+    }];
+}
+
+- (void)updateSharedNotebook:(EDAMSharedNotebook *)sharedNotebook
+                     success:(void(^)(int32_t usn))success
+                     failure:(void(^)(NSError *error))failure
+{
+    [self updateSharedNotebook:sharedNotebook completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
+}
+
+- (void) setSharedNotebookRecipientSettingsWithSharedNotebookId: (int64_t) sharedNotebookId
+                                              recipientSettings: (EDAMSharedNotebookRecipientSettings *) recipientSettings
+                                                        success:(void(^)(int32_t usn))success
+                                                        failure:(void(^)(NSError *error))failure
+{
+    [self setRecipientSettings:recipientSettings forSharedNotebookWithID:sharedNotebookId completion:^(int32_t usn, NSError * _Nullable error) {
+        (error != nil) ? success(usn) : failure(error);
+    }];
 }
 
 @end

--- a/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.h
@@ -47,106 +47,112 @@ NS_ASSUME_NONNULL_BEGIN
  
  @param  edamVersionMajor This should be the major protocol version that was compiled by the client. This should be the current value of the EDAM_VERSION_MAJOR constant for the client.
  @param  edamVersionMinor This should be the major protocol version that was compiled by the client. This should be the current value of the EDAM_VERSION_MINOR constant for the client.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)checkVersionWithClientName:(NSString *)clientName
                   edamVersionMajor:(int16_t)edamVersionMajor
                   edamVersionMinor:(int16_t)edamVersionMinor
-                           success:(void(^)(BOOL versionOK))success
-                           failure:(void(^)(NSError *error))failure;
+                        completion:(void(^)(BOOL versionOK, NSError *_Nullable error))completion;
 
 /** This provides bootstrap information to the client.
  
  Various bootstrap profiles and settings may be used by the client to configure itself.
  
  @param  locale The client's current locale, expressed in language[_country] format. E.g., "en_US". See ISO-639 and ISO-3166 for valid language and country codes.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchBootstrapInfoWithLocale:(NSString *)locale
-                             success:(void(^)(EDAMBootstrapInfo *info))success
-                             failure:(void(^)(NSError *error))failure;
-
-- (void)getBootstrapInfoWithLocale:(NSString *)locale
-                           success:(void(^)(EDAMBootstrapInfo *info))success
-                           failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchBootstrapInfoWithLocale:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                          completion:(void(^)(EDAMBootstrapInfo *_Nullable info, NSError *_Nullable error))completion;
 
 /** Returns the User corresponding to the provided authentication token, or throws an exception if this token is not valid.
  
  The level of detail provided in the returned User structure depends on the access level granted by the token, so a web service client may receive fewer fields than an integrated desktop client.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)fetchUserWithSuccess:(void(^)(EDAMUser *user))success
-                     failure:(void(^)(NSError *error))failure;
-
-- (void)getUserWithSuccess:(void(^)(EDAMUser *user))success
-                   failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchUserWithSuccess:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+- (void)fetchUserWithCompletion:(void(^)(EDAMUser *_Nullable user, NSError *_Nullable error))completion;
 
 /** Asks the UserStore about the publicly available location information for a particular username.
  
  @param username The username for the location information
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
 - (void)fetchPublicUserInfoWithUsername:(NSString *)username
-                                success:(void(^)(EDAMPublicUserInfo *info))success
-                                failure:(void(^)(NSError *error))failure;
-
-- (void)getPublicUserInfoWithUsername:(NSString *)username
-                              success:(void(^)(EDAMPublicUserInfo *info))success
-                              failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchPublicUserInfoWithUsername:success:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+                             completion:(void(^)(EDAMPublicUserInfo *_Nullable info, NSError *_Nullable error))completion;
 
 /** Returns information regarding a user's Premium account corresponding to the provided authentication token, or throws an exception if this token is not valid.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)fetchPremiumInfoWithSuccess:(void(^)(EDAMPremiumInfo *info))success
-                            failure:(void(^)(NSError *error))failure;
-
-- (void)getPremiumInfoWithSuccess:(void(^)(EDAMPremiumInfo *info))success
-                          failure:(void(^)(NSError *error))failure
-	DEPRECATED_MSG_ATTRIBUTE("Use -fetchPremiumInfoWithSuccess:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+- (void)fetchPremiumInfoWithCompletion:(void(^)(EDAMPremiumInfo *_Nullable info, NSError *_Nullable error))completion;
 
 /** Returns the URL that should be used to talk to the NoteStore for the account represented by the provided authenticationToken.
  
  This method isn't needed by most clients, who can retrieve the correct NoteStore URL from the AuthenticationResult returned from the authenticate or refreshAuthentication calls. This method is typically only needed to look up the correct URL for a long-lived session token (e.g. for an OAuth web service).
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)fetchNoteStoreURLWithSuccess:(void(^)(NSString *noteStoreUrl))success
-                             failure:(void(^)(NSError *error))failure;
-
-- (void)getNoteStoreUrlWithSuccess:(void(^)(NSString *noteStoreUrl))success
-                           failure:(void(^)(NSError *error))failure
-    DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteStoreURLWithSuccess:failure: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+- (void)fetchNoteStoreURLWithCompletion:(void(^)(NSString *_Nullable noteStoreUrl, NSError *_Nullable error))completion;
 
 /** This is used to take an existing authentication token that grants access to an individual user account (returned from 'authenticate', 'authenticateLongSession' or an OAuth authorization) and obtain an additional authentication token that may be used to access business notebooks if the user is a member of an Evernote Business account.
  
  The resulting authentication token may be used to make NoteStore API calls against the business using the NoteStore URL returned in the result.
  
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block (if the error parameter is set, then the value of the first parameter is undefined)
  */
-- (void)authenticateToBusinessWithSuccess:(void(^)(EDAMAuthenticationResult *authenticationResult))success
-                                  failure:(void(^)(NSError *error))failure;
+- (void)authenticateToBusinessWithCompletion:(void(^)(EDAMAuthenticationResult *_Nullable authenticationResult, NSError *_Nullable error))completion;
 
 /** Revoke an existing long lived authentication token. This can be used to revoke OAuth tokens or tokens created by calling authenticateLongSession, and allows a user to effectively log out of Evernote from the perspective of the application that holds the token. The authentication token that is passed is immediately revoked and may not be used to call any authenticated EDAM function.
  
  @param authenticationToken the authentication token to revoke.
- @param success Success completion block.
- @param failure Failure completion block.
+ @param completion Completion block
  */
 - (void)revokeLongSessionWithAuthenticationToken:(NSString*)authenticationToken
+                                      completion:(void(^)(NSError *_Nullable error))completion;
+@end
+
+
+
+//Deprecated
+@interface ENUserStoreClient ()
+
+- (void)checkVersionWithClientName:(NSString *)clientName
+                  edamVersionMajor:(int16_t)edamVersionMajor
+                  edamVersionMinor:(int16_t)edamVersionMinor
+                           success:(void(^)(BOOL versionOK))success
+                           failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -checkVersionWithClientName:edamVersionMajor:edamVersionMinor:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getBootstrapInfoWithLocale:(NSString *)locale
+                           success:(void(^)(EDAMBootstrapInfo *info))success
+                           failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -fetchBootstrapInfoWithLocale:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getUserWithSuccess:(void(^)(EDAMUser *user))success
+                   failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -fetchUserWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getPublicUserInfoWithUsername:(NSString *)username
+                              success:(void(^)(EDAMPublicUserInfo *info))success
+                              failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -fetchPublicUserInfoWithUsername:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getPremiumInfoWithSuccess:(void(^)(EDAMPremiumInfo *info))success
+                          failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -fetchPremiumInfoWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)getNoteStoreUrlWithSuccess:(void(^)(NSString *noteStoreUrl))success
+                           failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -fetchNoteStoreURLWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)authenticateToBusinessWithSuccess:(void(^)(EDAMAuthenticationResult *authenticationResult))success
+                                  failure:(void(^)(NSError *error))failure
+    DEPRECATED_MSG_ATTRIBUTE("Use -authenticateToBusinessWithCompletion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
+
+- (void)revokeLongSessionWithAuthenticationToken:(NSString*)authenticationToken
                                          success:(void(^)())success
-                                         failure:(void(^)(NSError *error))failure;
+                                         failure:(void(^)(NSError *error))failure
+	DEPRECATED_MSG_ATTRIBUTE("Use -revokeLongSessionWithAuthenticationToken:completion: instead") NS_SWIFT_UNAVAILABLE("Deprecated");
 @end
 
 NS_ASSUME_NONNULL_END

--- a/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Advanced/ENUserStoreClient.m
@@ -67,106 +67,136 @@
 - (void)checkVersionWithClientName:(NSString *)clientName
                   edamVersionMajor:(int16_t)edamVersionMajor
                   edamVersionMinor:(int16_t)edamVersionMinor
-                           success:(void(^)(BOOL versionOK))success
-                           failure:(void(^)(NSError *error))failure
+                                completion:(void(^)(BOOL versionOK, NSError *error))completion
 
 {
     [self invokeAsyncBoolBlock:^BOOL{
         return [self.client checkVersion:clientName edamVersionMajor:edamVersionMajor edamVersionMinor:edamVersionMinor];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchBootstrapInfoWithLocale:(NSString *)locale
-                             success:(void(^)(EDAMBootstrapInfo *info))success
-                             failure:(void(^)(NSError *error))failure
+                          completion:(void(^)(EDAMBootstrapInfo *info, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getBootstrapInfo:locale];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)fetchUserWithSuccess:(void(^)(EDAMUser *user))success
-                     failure:(void(^)(NSError *error))failure
+- (void)fetchUserWithCompletion:(void(^)(EDAMUser *user, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getUser:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)fetchPublicUserInfoWithUsername:(NSString *)username
-                                success:(void(^)(EDAMPublicUserInfo *info))success
-                                failure:(void(^)(NSError *error))failure
+                             completion:(void(^)(EDAMPublicUserInfo *info, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getPublicUserInfo:username];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)fetchPremiumInfoWithSuccess:(void(^)(EDAMPremiumInfo *info))success
-                            failure:(void(^)(NSError *error))failure
+- (void)fetchPremiumInfoWithCompletion:(void(^)(EDAMPremiumInfo *info, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getPremiumInfo:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)fetchNoteStoreURLWithSuccess:(void(^)(NSString *noteStoreUrl))success
-                             failure:(void(^)(NSError *error))failure
+- (void)fetchNoteStoreURLWithCompletion:(void(^)(NSString *noteStoreUrl, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client getNoteStoreUrl:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
-- (void)authenticateToBusinessWithSuccess:(void(^)(EDAMAuthenticationResult *authenticationResult))success
-                                  failure:(void(^)(NSError *error))failure
+- (void)authenticateToBusinessWithCompletion:(void(^)(EDAMAuthenticationResult *authenticationResult, NSError *error))completion
 {
-    [self invokeAsyncIdBlock:^id {
+    [self invokeAsyncObjectBlock:^id {
         return [self.client authenticateToBusiness:self.authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 - (void)revokeLongSessionWithAuthenticationToken:(NSString*)authenticationToken
-                                         success:(void(^)())success
-                                         failure:(void(^)(NSError *error))failure {
-    [self invokeAsyncVoidBlock:^void {
+                                      completion:(void(^)(NSError *error))completion {
+    [self invokeAsyncBlock:^void {
         [self.client revokeLongSession:authenticationToken];
-    } success:success failure:failure];
+    } completion:completion];
 }
 
 
 #pragma mark - Deprecated
 
+- (void)checkVersionWithClientName:(NSString *)clientName
+                  edamVersionMajor:(int16_t)edamVersionMajor
+                  edamVersionMinor:(int16_t)edamVersionMinor
+                           success:(void(^)(BOOL versionOK))success
+                           failure:(void(^)(NSError *error))failure
+
+{
+    [self checkVersionWithClientName:clientName edamVersionMajor:edamVersionMajor edamVersionMinor:edamVersionMinor completion:^(BOOL versionOK, NSError *error) {
+        (error != nil) ? success(versionOK) : failure(error);
+    }];
+}
+
 - (void)getBootstrapInfoWithLocale:(NSString *)locale
                            success:(void(^)(EDAMBootstrapInfo *info))success
                            failure:(void(^)(NSError *error))failure
 {
-    [self fetchBootstrapInfoWithLocale:locale success:success failure:failure];
+    [self fetchBootstrapInfoWithLocale:locale completion:^(EDAMBootstrapInfo *info, NSError *error) {
+        (error != nil) ? success(info) : failure(error);
+    }];
 }
 
 - (void)getUserWithSuccess:(void(^)(EDAMUser *user))success
                    failure:(void(^)(NSError *error))failure
 {
-    [self fetchUserWithSuccess:success failure:failure];
+    [self fetchUserWithCompletion:^(EDAMUser * user, NSError * error) {
+        (error != nil) ? success(user) : failure(error);
+    }];
 }
 
 - (void)getPublicUserInfoWithUsername:(NSString *)username
                               success:(void(^)(EDAMPublicUserInfo *info))success
                               failure:(void(^)(NSError *error))failure
 {
-    [self fetchPublicUserInfoWithUsername:username success:success failure:failure];
+    [self fetchPublicUserInfoWithUsername:username completion:^(EDAMPublicUserInfo *info, NSError *error) {
+        (error != nil) ? success(info) : failure(error);
+    }];
 }
 
 - (void)getPremiumInfoWithSuccess:(void(^)(EDAMPremiumInfo *info))success
                           failure:(void(^)(NSError *error))failure
 {
-    [self fetchPremiumInfoWithSuccess:success failure:failure];
+    [self fetchPremiumInfoWithCompletion:^(EDAMPremiumInfo *info, NSError *error) {
+        (error != nil) ? success(info) : failure(error);
+    }];
 }
 
 - (void)getNoteStoreUrlWithSuccess:(void(^)(NSString *noteStoreUrl))success
                            failure:(void(^)(NSError *error))failure
 {
-    [self fetchNoteStoreURLWithSuccess:success failure:failure];
+    [self fetchNoteStoreURLWithCompletion:^(NSString *noteStoreUrl, NSError *error) {
+        (error != nil) ? success(noteStoreUrl) : failure(error);
+    }];
+}
+
+- (void)authenticateToBusinessWithSuccess:(void(^)(EDAMAuthenticationResult *authenticationResult))success
+                                  failure:(void(^)(NSError *error))failure
+{
+    [self authenticateToBusinessWithCompletion:^(EDAMAuthenticationResult *authenticationResult, NSError *error) {
+        (error != nil) ? success(authenticationResult) : failure(error);
+    }];
+}
+
+- (void)revokeLongSessionWithAuthenticationToken:(NSString*)authenticationToken
+                                         success:(void(^)())success
+                                         failure:(void(^)(NSError *error))failure {
+    [self revokeLongSessionWithAuthenticationToken:authenticationToken completion:^(NSError *error) {
+        (error != nil) ? success() : failure(error);
+    }];
 }
 
 @end

--- a/evernote-sdk-ios/ENSDK/Private/ENOAuthAuthenticator.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENOAuthAuthenticator.m
@@ -143,15 +143,17 @@ NSString * ENOAuthAuthenticatorAuthInfoAppNotebookIsLinked = @"ENOAuthAuthentica
     // Start bootstrapping
     NSString * locale = [[NSLocale currentLocale] localeIdentifier];
     ENUserStoreClient * userStore = [self.delegate userStoreClientForBootstrapping];
-    [userStore fetchBootstrapInfoWithLocale:locale success:^(EDAMBootstrapInfo *info) {
+    [userStore fetchBootstrapInfoWithLocale:locale completion:^(EDAMBootstrapInfo *info, NSError *error) {
+        if (error) {
+            // start the OAuth dance to get credentials (auth token, noteStoreUrl, etc).
+            [self startOauthAuthentication];
+            return;
+        }
         // Using first profile as the preferred profile.
         EDAMBootstrapProfile * profile = [info.profiles objectAtIndex:0];
         self.profiles = info.profiles;
         self.currentProfile = profile.name;
         self.host = profile.settings.serviceHost;
-        // start the OAuth dance to get credentials (auth token, noteStoreUrl, etc).
-        [self startOauthAuthentication];
-    } failure:^(NSError * error) {
         // start the OAuth dance to get credentials (auth token, noteStoreUrl, etc).
         [self startOauthAuthentication];
     }];

--- a/evernote-sdk-ios/ENSDK/Private/ENStoreClient.h
+++ b/evernote-sdk-ios/ENSDK/Private/ENStoreClient.h
@@ -29,19 +29,18 @@
 #import <Foundation/Foundation.h>
 @class ENStoreClient;
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * ENStoreClientDidFailWithAuthenticationErrorNotification;
 
 @interface ENStoreClient : NSObject
-- (void)invokeAsyncBoolBlock:(BOOL(^)())block
-                     success:(void(^)(BOOL val))success
-                     failure:(void(^)(NSError * error))failure;
-- (void)invokeAsyncIdBlock:(id(^)())block
-                   success:(void(^)(id))success
-                   failure:(void(^)(NSError * error))failure;
-- (void)invokeAsyncInt32Block:(int32_t(^)())block
-                      success:(void(^)(int32_t val))success
-                      failure:(void(^)(NSError * error))failure;
-- (void)invokeAsyncVoidBlock:(void(^)())block
-                     success:(void(^)())success
-                     failure:(void(^)(NSError * error))failure;
+
+- (void)invokeAsyncBoolBlock:(BOOL(^)())block completion:(void (^)(BOOL value, NSError *_Nullable error))completion;
+- (void)invokeAsyncObjectBlock:(nullable id(^)())block completion:(void (^)(id _Nullable value, NSError *_Nullable error))completion;
+- (void)invokeAsyncInt32Block:(int32_t(^)())block completion:(void (^)(int32_t value, NSError *_Nullable error))completion;
+- (void)invokeAsyncBlock:(void(^)())block completion:(void (^)(NSError *_Nullable error))completion;
+
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/evernote-sdk-ios/ENSDK/Private/ENStoreClient.m
+++ b/evernote-sdk-ios/ENSDK/Private/ENStoreClient.m
@@ -50,109 +50,83 @@ NSString * ENStoreClientDidFailWithAuthenticationErrorNotification = @"ENStoreCl
     return self;
 }
 
-- (void)invokeAsyncBoolBlock:(BOOL(^)())block
-                     success:(void(^)(BOOL val))success
-                     failure:(void(^)(NSError *error))failure
+- (void)invokeAsyncBoolBlock:(BOOL(^)())block completion:(void (^)(BOOL val, NSError *error))completion
 {
     dispatch_async(self.queue, ^(void) {
         __block BOOL retVal = NO;
         @try {
-            if (block) {
-                retVal = block();
-                dispatch_async(dispatch_get_main_queue(),
-                               ^{
-                                   if (success) {
-                                       success(retVal);
-                                   }
-                               });
-            }
+            retVal = block();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(retVal, nil);
+            });
         }
         @catch (NSException *exception) {
-            [self handleException:exception withFailureBlock:failure];
+            NSError * error = [ENError errorFromException:exception];
+            completion(NO, error);
+            [self handleError:error];
         }
     });
 }
 
-- (void)invokeAsyncInt32Block:(int32_t(^)())block
-                      success:(void(^)(int32_t val))success
-                      failure:(void(^)(NSError *error))failure
+- (void)invokeAsyncInt32Block:(int32_t(^)())block completion:(void (^)(int32_t val, NSError *_Nullable error))completion
 {
     dispatch_async(self.queue, ^(void) {
         __block int32_t retVal = -1;
         @try {
-            if (block) {
-                retVal = block();
-                dispatch_async(dispatch_get_main_queue(),
-                               ^{
-                                   if (success) {
-                                       success(retVal);
-                                   }
-                               });
-            }
+            retVal = block();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(retVal, nil);
+            });
         }
         @catch (NSException *exception) {
-            [self handleException:exception withFailureBlock:failure];
+            NSError * error = [ENError errorFromException:exception];
+            completion(-1, error);
+            [self handleError:error];
         }
     });
 }
 
 // use id instead of NSObject* so block type-checking is happy
-- (void)invokeAsyncIdBlock:(id(^)())block
-                   success:(void(^)(id))success
-                   failure:(void(^)(NSError *error))failure
+- (void)invokeAsyncObjectBlock:(nullable id(^)())block completion:(void (^)(id _Nullable val, NSError *_Nullable error))completion
+
 {
     dispatch_async(self.queue, ^(void) {
         id retVal = nil;
         @try {
-            if (block) {
-                retVal = block();
-                dispatch_async(dispatch_get_main_queue(),
-                               ^{
-                                   if (success) {
-                                       success(retVal);
-                                   }
-                               });
-            }
+            retVal = block();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(retVal, nil);
+            });
         }
         @catch (NSException *exception) {
-            [self handleException:exception withFailureBlock:failure];
+            NSError * error = [ENError errorFromException:exception];
+            completion(nil, error);
+            [self handleError:error];
         }
     });
 }
 
-- (void)invokeAsyncVoidBlock:(void(^)())block
-                     success:(void(^)())success
-                     failure:(void(^)(NSError *error))failure
+- (void)invokeAsyncBlock:(void(^)())block completion:(void (^)(NSError *_Nullable error))completion
 {
     dispatch_async(self.queue, ^(void) {
         @try {
-            if (block) {
-                block();
-                dispatch_async(dispatch_get_main_queue(),
-                               ^{
-                                   if (success) {
-                                       success();
-                                   }
-                               });
-            }
+            block();
+            dispatch_async(dispatch_get_main_queue(), ^{
+                completion(nil);
+            });
         }
         @catch (NSException *exception) {
-            [self handleException:exception withFailureBlock:failure];
+            NSError * error = [ENError errorFromException:exception];
+            completion(error);
+            [self handleError:error];
         }
     });
 }
 
 #pragma mark - Private routines
 
-- (void)handleException:(NSException *)exception withFailureBlock:(void(^)(NSError *error))failure
+- (void)handleError:(NSError *)error
 {
-    NSError * error = [ENError errorFromException:exception];
-    if (failure) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            failure(error);
-        });
-    }
-    
     // If this is a hard auth error, then send a notification about it. This is intended to trigger for
     // tokens that have either expired or that have been revoked. This does NOT include permissions
     // denials (ie, the auth token is valid, but not for the operation you're trying to do with it). Those


### PR DESCRIPTION
- Merged success/failure blocks into single completion blocks (should be nicer to use in swift)
- Deprecated -findNoteCountsWithFilter:withTrash:success:failure: in favour of -findNoteCountsWithFilter:includingTrash:completion: